### PR TITLE
Add bare encoder support: docs, wiring, and firmware fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,17 @@ This project interfaces four rotary encoders, each with a push‑button shaft, t
 ## Hardware Components
 
 - Raspberry Pi Pico (or Pico W).
-- 4× rotary encoders with push‑button shafts (e.g., KY‑040 or similar 5‑pin modules).
+- 4× rotary encoders with push‑button shafts — either type works:
+  - **Bare encoders** (e.g., [Cylewet CYT1100](https://www.amazon.com/Cylewet-Encoder-Digital-Potentiometer-Arduino/dp/B07DM2YMT4) — 3+2 pin, no PCB)
+  - **Module encoders** (e.g., [Cylewet KY‑040 CYT1062](https://www.amazon.com/Cylewet-Encoder-15%C3%9716-5-Arduino-CYT1062/dp/B06XQTHDRR) — 5‑pin PCB with onboard pull‑ups)
 - Breadboard and jumper wires.
-- Optional: 10 kΩ resistors (external pull‑ups if desired, often not needed when using internal pull‑ups).
 - USB micro‑B cable to connect Pico to PC.
 
 Notes:
 
+- **No external pull‑up resistors are required** with either encoder type. The firmware enables the Pico’s internal pull‑ups (~50–80 kΩ) on all encoder GPIO pins.
 - Typical “5 V” KY‑040 modules are safe to use at 3.3 V with the Pico; they are just mechanical switches plus resistors.
-- You can omit the encoder “+” pin entirely if you rely on the Pico’s internal pull‑ups and treat the encoder as just switches to ground.
+- Bare encoders are also just mechanical switches to ground and work identically with the Pico’s internal pull‑ups — simply leave any “+” or VCC pin unconnected.
 
 ---
 
@@ -184,7 +186,7 @@ Notes:
             GP17 ───┤ 20                       21 ├─── GP16
                     └─────────────────────────────┘
 
-               ENCODER MODULE (KY-040 Style)
+               ENCODER TYPE A: KY-040 MODULE (5-pin PCB)
               ┌─────────────────────────────┐
               │         ┌───────┐           │
               │         │ENCODER│           │
@@ -196,7 +198,7 @@ Notes:
                   │     │    │   │    │
                   │     │    │   │    └──────► Pico GND (Pin 3, 8, 13, 18, 23, 28, 33, 38)
                   │     │    │   │
-                  │     │    │   └───────────► Pico 3V3 (Pin 36) OR leave NC*
+                  │     │    │   └───────────► NC (leave unconnected)*
                   │     │    │
                   │     │    └───────────────► Pico GPIO (SW pin)
                   │     │
@@ -204,10 +206,36 @@ Notes:
                   │
                   └──────────────────────────► Pico GPIO (CLK/A pin)
 
-              * NC = Not Connected (recommended when using internal pull-ups)
+              * NC = Not Connected (recommended — Pico internal pull-ups provide the HIGH reference)
+
+
+               ENCODER TYPE B: BARE ENCODER (3+2 pin, no PCB)
+
+                      ┌─────────┐
+                      │  KNOB   │
+                      │  SHAFT  │
+                 ┌────┴─────────┴────┐
+                 │   ROTARY ENCODER   │
+                 └─┬──────┬──────┬───┘
+                   │      │      │         3-pin side (rotary quadrature)
+                   │      │      │
+                   │      │      └─────────► Pico GPIO (B/DT pin)
+                   │      │
+                   │      └────────────────► Pico GND (center pin = common ground)
+                   │
+                   └───────────────────────► Pico GPIO (A/CLK pin)
+
+                 └───┬──────┬───┘
+                     │      │              2-pin side (push button)
+                     │      │
+                     │      └──────────────► Pico GND
+                     │
+                     └─────────────────────► Pico GPIO (SW pin)
 ```
 
-### Breadboard Wiring Example
+### Breadboard Wiring Examples
+
+#### Using KY‑040 Modules (5‑pin PCB)
 
 ```
  ENCODER 1        ENCODER 2        ENCODER 3        ENCODER 4
@@ -227,10 +255,40 @@ Notes:
   │ │ └──GP4       │ │ └──GP7       │ │ └──GP10      │ │ └──GP13
   │ └────GP3       │ └────GP6       │ └────GP9       │ └────GP12
   └──────GP2       └──────GP5       └──────GP8       └──────GP11
+```
 
+#### Using Bare Encoders (3+2 pin, no PCB)
+
+```
+ ENCODER 1            ENCODER 2            ENCODER 3            ENCODER 4
+ ┌─────────┐          ┌─────────┐          ┌─────────┐          ┌─────────┐
+ │  ┌───┐  │          │  ┌───┐  │          │  ┌───┐  │          │  ┌───┐  │
+ │  │ ○ │  │          │  │ ○ │  │          │  │ ○ │  │          │  │ ○ │  │
+ │  └───┘  │          │  └───┘  │          │  └───┘  │          │  └───┘  │
+ │A  GND  B│          │A  GND  B│          │A  GND  B│          │A  GND  B│
+ └┬───┬───┬┘          └┬───┬───┬┘          └┬───┬───┬┘          └┬───┬───┬┘
+  │   │   │            │   │   │            │   │   │            │   │   │
+  │   │   │            │   │   │            │   │   │            │   │   │
+  │   └───┼────────────┼───┴───┼────────────┼───┴───┼────────────┼───┴───┼──► GND Rail
+  │       │            │       │            │       │            │       │
+  │       └──GP3       │       └──GP6       │       └──GP9       │       └──GP12
+  └──────────GP2       └──────────GP5       └──────────GP8       └──────────GP11
+
+  (Push-button pins, 2-pin side of each encoder)
+  SW1  SW2            SW1  SW2            SW1  SW2            SW1  SW2
+  ┬─────┬              ┬─────┬              ┬─────┬              ┬─────┬
+  │     │              │     │              │     │              │     │
+  │     └──► GND Rail  │     └──► GND Rail  │     └──► GND Rail  │     └──► GND Rail
+  │                    │                    │                    │
+  └──GP4               └──GP7               └──GP10              └──GP13
+```
+
+#### Breadboard Layout (either encoder type)
+
+```
                         BREADBOARD LAYOUT
   ┌──────────────────────────────────────────────────────────────┐
-  │  ═══════════════════════════════════════════════════════════ │◄─ Power Rail (+)
+  │  ═══════════════════════════════════════════════════════════ │◄─ Power Rail (+) (unused)
   │  ═══════════════════════════════════════════════════════════ │◄─ GND Rail (-)
   │                                                              │
   │   [ENC1]    [ENC2]    [ENC3]    [ENC4]     [PICO]           │
@@ -252,6 +310,10 @@ Notes:
   │                                            │     │          │
   │  ═══════════════════════════════════════════════════════════ │◄─ Connect to Pico GND
   └──────────────────────────────────────────────────────────────┘
+
+  Note: For bare encoders, the center pin on the 3-pin side and one
+  push-button pin must also connect to the GND rail. For KY-040
+  modules, only the GND pin needs the GND rail (leave + unconnected).
 ```
 
 ### Voltage Levels and Level Shifting
@@ -268,24 +330,24 @@ Notes:
 | **Absolute Maximum** | **3.63V** | **Exceeding this WILL damage the Pico!** |
 | Internal Pull-up | ~50-80kΩ | Pulls GPIO to 3.3V when enabled |
 
-#### Why Level Shifting is NOT Required for KY-040 Encoders
+#### Why Level Shifting and External Pull‑Ups are NOT Required
 
-Despite being labeled as "5V" modules, KY-040 encoders work safely with the Pico because:
+Both KY‑040 modules and bare encoders work safely with the Pico without any external resistors because:
 
-1. **Open-Drain/Open-Collector Operation**: The encoder outputs (CLK, DT, SW) are mechanical switches that connect to GND when activated. They do not output voltage - they only pull the line LOW.
+1. **Open-Drain/Open-Collector Operation**: All rotary encoder outputs (CLK/A, DT/B, SW) are mechanical switches that connect to GND when activated. They do not output voltage — they only pull the line LOW. This is true for both bare encoders and module encoders.
 
-2. **Pull-up Resistor Location**: When using internal pull-ups (recommended), the Pico's 3.3V internal pull-ups define the HIGH voltage level. The encoder module's onboard pull-ups (typically 10kΩ to VCC) are either:
-   - Not connected (if you leave the `+` pin unconnected)
-   - Connected to 3.3V (if you wire `+` to Pico 3V3)
+2. **Pull-up Resistor Source**: The Pico's internal pull‑ups (~50–80 kΩ to 3.3 V) define the HIGH voltage level. No external pull‑ups are needed:
+   - **Bare encoders** have no onboard resistors at all — the Pico's internal pull‑ups are sufficient.
+   - **KY‑040 modules** have onboard 10 kΩ pull‑ups, but these are either not connected (if you leave the `+` pin unconnected) or safely connected to 3.3 V (if you wire `+` to Pico 3V3). Either way, the Pico's internal pull‑ups work in parallel.
 
-3. **Safe Signal Flow**:
+3. **Safe Signal Flow (both encoder types)**:
    ```
-   With internal pull-ups (RECOMMENDED):
-   
+   With Pico internal pull-ups (RECOMMENDED — no external resistors needed):
+
    Pico GPIO ◄────┬──── ~50-80kΩ ────► 3.3V (internal pull-up)
                   │
                   └──── Encoder Switch ────► GND
-   
+
    Switch OPEN:  GPIO reads HIGH (3.3V from internal pull-up)
    Switch CLOSED: GPIO reads LOW (connected to GND through switch)
    ```
@@ -359,6 +421,61 @@ External 3.3V Regulated PSU ────► 3V3 (Pin 36) ────► Pico & 
 
 ## Encoder Pinout And Pico Wiring
 
+### Compatible Encoder Types
+
+This project supports two common encoder form factors. Both are mechanical switches internally and work with the Pico's internal pull‑ups — **no external pull‑up resistors are needed**.
+
+#### Type A: KY‑040 Module (5‑pin PCB)
+
+A rotary encoder soldered onto a small breakout board with labeled pins and onboard 10 kΩ pull‑up resistors.
+
+Example: [Cylewet KY‑040 CYT1062 (5‑pack)](https://www.amazon.com/Cylewet-Encoder-15%C3%9716-5-Arduino-CYT1062/dp/B06XQTHDRR)
+
+```
+  KY-040 MODULE (top view)
+  ┌─────────────────────┐
+  │      ┌───────┐      │
+  │      │ENCODER│      │
+  │      │ KNOB  │      │
+  │      └───────┘      │
+  │  [R1]  [R2]  [R3]   │  ← Onboard 10kΩ pull-up resistors
+  │                      │
+  │ [CLK] [DT] [SW] [+] [GND]
+  └──┬─────┬────┬───┬────┬──┘
+     │     │    │   │    │
+     A     B   SW  VCC  GND
+```
+
+**Pins:** CLK (A), DT (B), SW (button), + (VCC), GND
+
+#### Type B: Bare Encoder (3+2 pin, no PCB)
+
+A standalone encoder component with no breakout board and no onboard resistors. Pins are split across two sides of the encoder body.
+
+Example: [Cylewet CYT1100 (5‑pack with knob caps)](https://www.amazon.com/Cylewet-Encoder-Digital-Potentiometer-Arduino/dp/B07DM2YMT4)
+
+```
+  BARE ENCODER (side view)
+
+       ┌─────────┐
+       │  KNOB   │
+       │  SHAFT  │
+  ┌────┴─────────┴────┐
+  │                    │
+  │   ROTARY ENCODER   │
+  │                    │
+  └─┬──────┬──────┬───┘
+    │      │      │        ← 3-pin side (rotary)
+    A    GND(C)   B
+
+  └───┬──────┬───┘
+      │      │             ← 2-pin side (push button)
+     SW1    SW2
+```
+
+**3‑pin side:** A (CLK), C (common/GND), B (DT)
+**2‑pin side:** SW1, SW2 (push button — normally open, either pin can be GND)
+
 ### Typical encoder pins
 
 For a common 5‑pin rotary encoder module (KY‑040‑style):
@@ -369,26 +486,43 @@ For a common 5‑pin rotary encoder module (KY‑040‑style):
 - + – Optional VCC (often labeled 5V but workable at 3.3 V).
 - GND – Ground.
 
-Internally, A/B/SW are just switches that connect to ground when activated; the microcontroller provides pull‑ups.
+For a bare encoder (3+2 pin):
+
+- A – Quadrature signal 1 (3‑pin side, outer pin).
+- C – Common/ground (3‑pin side, center pin).
+- B – Quadrature signal 2 (3‑pin side, outer pin).
+- SW1/SW2 – Push‑button terminals (2‑pin side, normally open).
+
+Internally, all encoder types are just switches that connect to ground when activated; the microcontroller provides pull‑ups.
 
 ### GPIO assignment
 
-Use 4 encoders × (A, B, SW) = 12 GPIO pins. All encoders share 3V3 and GND rails.
+Use 4 encoders × (A, B, SW) = 12 GPIO pins. All encoders share GND rails.
 
-| Encoder | A (CLK) | B (DT) | SW (Button) | VCC (+)      | GND       |
-|---------|---------|--------|-------------|--------------|-----------|
-| 1       | GP2     | GP3    | GP4         | Pico 3V3 or NC | Pico GND |
-| 2       | GP5     | GP6    | GP7         | Pico 3V3 or NC | Pico GND |
-| 3       | GP8     | GP9    | GP10        | Pico 3V3 or NC | Pico GND |
-| 4       | GP11    | GP12   | GP13        | Pico 3V3 or NC | Pico GND |
+#### Wiring: KY‑040 Module (5‑pin)
+
+| Encoder | CLK → | DT → | SW → | + (VCC) | GND → |
+|---------|-------|------|------|---------|-------|
+| 1       | GP2   | GP3  | GP4  | NC (leave unconnected) | Pico GND |
+| 2       | GP5   | GP6  | GP7  | NC (leave unconnected) | Pico GND |
+| 3       | GP8   | GP9  | GP10 | NC (leave unconnected) | Pico GND |
+| 4       | GP11  | GP12 | GP13 | NC (leave unconnected) | Pico GND |
+
+#### Wiring: Bare Encoder (3+2 pin)
+
+| Encoder | A → | B → | C (center) → | SW1 → | SW2 → |
+|---------|-----|-----|--------------|-------|-------|
+| 1       | GP2 | GP3 | Pico GND     | GP4   | Pico GND |
+| 2       | GP5 | GP6 | Pico GND     | GP7   | Pico GND |
+| 3       | GP8 | GP9 | Pico GND     | GP10  | Pico GND |
+| 4       | GP11| GP12| Pico GND     | GP13  | Pico GND |
 
 Wiring rules:
 
-- Connect all encoder GND pins to any Pico GND pins (tie grounds together on the breadboard).
-- Either:
-  - Connect all “+” pins to Pico 3V3, **or**
-  - Leave “+” unconnected and enable internal pull‑ups on A/B/SW lines in software (recommended and commonly used).
-- Each A/B/SW pin goes directly to its assigned Pico GPIO, no level shifting needed because the encoder only pulls to ground.
+- Connect all encoder GND/common pins to any Pico GND pins (tie grounds together on the breadboard).
+- For KY‑040 modules: leave the “+” pin unconnected (NC). The Pico's internal pull‑ups provide the HIGH reference.
+- For bare encoders: connect the center pin (C) to GND. Connect one push‑button pin to GPIO and the other to GND.
+- Each signal pin (A/B/SW) goes directly to its assigned Pico GPIO — no level shifting or external pull‑up resistors needed.
 
 Debounce and direction:
 
@@ -516,8 +650,9 @@ You can later port to C/C++ with the Pico SDK if you want lower‑level control.
 - **Noisy or bouncy encoders**  
   - Use proper software debounce and a quadrature state machine; consider using `rotaryio.Encoder` if supported in your CircuitPython version.
 
-- **Wrong wiring (5 V risk)**  
-  - Ensure encoder “+” is never tied to 5 V (VBUS) when wired to Pico GPIO; use 3.3 V or omit “+” entirely and use pull‑ups.
+- **Wrong wiring (5 V risk)**
+  - For KY‑040 modules: ensure encoder “+” is never tied to 5 V (VBUS); leave it unconnected (NC) or wire to 3.3 V only.
+  - For bare encoders: ensure signal pins (A, B, SW) connect only to Pico GPIO pins, and common/ground pins connect only to Pico GND.
 
 - **HID not appearing**  
   - Ensure CircuitPython build has HID enabled and `usb_hid` is imported and not disabled in `boot.py`.

--- a/firmware-cpp/README.md
+++ b/firmware-cpp/README.md
@@ -46,14 +46,30 @@ This C++ implementation offers several advantages over the CircuitPython version
 
 ## Hardware Setup
 
-Same wiring as the CircuitPython version:
+Same wiring as the CircuitPython version. Both encoder types are supported — **no external pull‑up resistors needed** (firmware enables Pico internal pull‑ups):
 
-| Encoder | A (CLK) | B (DT) | SW (Button) | VCC (+)   | GND |
-|---------|---------|--------|-------------|-----------|-----|
-| 1       | GP2     | GP3    | GP4         | 3V3 or NC | GND |
-| 2       | GP5     | GP6    | GP7         | 3V3 or NC | GND |
-| 3       | GP8     | GP9    | GP10        | 3V3 or NC | GND |
-| 4       | GP11    | GP12   | GP13        | 3V3 or NC | GND |
+- **[KY‑040 modules](https://www.amazon.com/Cylewet-Encoder-15%C3%9716-5-Arduino-CYT1062/dp/B06XQTHDRR)** (5‑pin PCB with onboard pull‑ups)
+- **[Bare encoders](https://www.amazon.com/Cylewet-Encoder-Digital-Potentiometer-Arduino/dp/B07DM2YMT4)** (3+2 pin, no PCB)
+
+#### KY‑040 Module (5‑pin PCB)
+
+| Encoder | CLK → | DT → | SW → | + (VCC) | GND → |
+|---------|-------|------|------|---------|-------|
+| 1       | GP2   | GP3  | GP4  | NC (leave unconnected) | Pico GND |
+| 2       | GP5   | GP6  | GP7  | NC (leave unconnected) | Pico GND |
+| 3       | GP8   | GP9  | GP10 | NC (leave unconnected) | Pico GND |
+| 4       | GP11  | GP12 | GP13 | NC (leave unconnected) | Pico GND |
+
+#### Bare Encoder (3+2 pin, no PCB)
+
+| Encoder | A (outer pin) → | C (center pin) → | B (outer pin) → | SW1 → | SW2 → |
+|---------|-----------------|------------------|-----------------|-------|-------|
+| 1       | GP2             | Pico GND         | GP3             | GP4   | Pico GND |
+| 2       | GP5             | Pico GND         | GP6             | GP7   | Pico GND |
+| 3       | GP8             | Pico GND         | GP9             | GP10  | Pico GND |
+| 4       | GP11            | Pico GND         | GP12            | GP13  | Pico GND |
+
+See the [CircuitPython firmware README](../firmware/README.md) for detailed wiring notes.
 
 ## Prerequisites
 

--- a/firmware-cpp/encoder.cpp
+++ b/firmware-cpp/encoder.cpp
@@ -36,7 +36,8 @@ const int8_t Encoder::TRANSITION_TABLE[16] = {
 
 Encoder::Encoder(uint8_t pin_a, uint8_t pin_b, uint8_t pin_sw,
                  uint8_t keycode_cw, uint8_t keycode_ccw, uint8_t keycode_btn,
-                 uint8_t encoder_id)
+                 uint8_t encoder_id, int8_t steps_per_detent,
+                 bool reverse_direction)
     : pin_a_(pin_a)
     , pin_b_(pin_b)
     , pin_sw_(pin_sw)
@@ -45,9 +46,12 @@ Encoder::Encoder(uint8_t pin_a, uint8_t pin_b, uint8_t pin_sw,
     , keycode_btn_(keycode_btn)
     , last_ab_state_(0)
     , steps_(0)
+    , steps_per_detent_(steps_per_detent)
+    , reverse_direction_(reverse_direction)
     , last_button_state_(true)
     , button_pressed_(false)
-    , last_button_time_(0)
+    , debounce_start_(0)
+    , debounce_active_(false)
     , encoder_id_(encoder_id)
 {
 }
@@ -90,57 +94,61 @@ bool Encoder::update(uint8_t& keycode) {
     uint8_t current_ab_state = read_ab_state();
 
     if (current_ab_state != last_ab_state_) {
-        // Look up transition in table
         uint8_t index = (last_ab_state_ << 2) | current_ab_state;
         int8_t direction = TRANSITION_TABLE[index];
 
         if (direction != 0) {
+            if (reverse_direction_) direction = -direction;
             steps_ += direction;
 
-            // Most encoders have 4 state changes per detent
-            // (adjust this value if your encoder behaves differently)
-            // Send key event when a full detent is completed
-            if (steps_ >= 4) {
+            if (steps_ >= steps_per_detent_) {
                 keycode = keycode_cw_;
                 steps_ = 0;
                 DEBUG_PRINT("Encoder %d: CW -> Key 0x%02X\n", encoder_id_, keycode);
                 last_ab_state_ = current_ab_state;
                 return true;
-            } else if (steps_ <= -4) {
+            } else if (steps_ <= -steps_per_detent_) {
                 keycode = keycode_ccw_;
                 steps_ = 0;
                 DEBUG_PRINT("Encoder %d: CCW -> Key 0x%02X\n", encoder_id_, keycode);
                 last_ab_state_ = current_ab_state;
                 return true;
             }
+        } else {
+            // Invalid transition (noise) — reset step accumulator
+            steps_ = 0;
         }
 
         last_ab_state_ = current_ab_state;
     }
 
-    // Process button press with debounce
+    // Process button with first-edge-latch debounce
     bool current_button_state = gpio_get(pin_sw_);
     uint32_t current_time = time_us_32();
 
-    // Button is active-low (pressed = false/low)
     if (current_button_state != last_button_state_) {
-        if ((current_time - last_button_time_) >= BUTTON_DEBOUNCE_US) {
-            last_button_time_ = current_time;
+        if (!debounce_active_) {
+            // First edge — start debounce window
+            debounce_start_ = current_time;
+            debounce_active_ = true;
+        } else if ((current_time - debounce_start_) >= BUTTON_DEBOUNCE_US) {
+            // Debounce period elapsed — commit the new state
             last_button_state_ = current_button_state;
+            debounce_active_ = false;
 
-            // Detect falling edge (button press)
             if (!current_button_state && !button_pressed_) {
                 button_pressed_ = true;
                 keycode = keycode_btn_;
                 DEBUG_PRINT("Encoder %d: BTN -> Key 0x%02X\n", encoder_id_, keycode);
                 return true;
-            }
-            // Detect rising edge (button release)
-            else if (current_button_state && button_pressed_) {
+            } else if (current_button_state && button_pressed_) {
                 button_pressed_ = false;
                 DEBUG_PRINT("Encoder %d: Button released\n", encoder_id_);
             }
         }
+    } else {
+        // Signal is stable — clear any pending debounce
+        debounce_active_ = false;
     }
 
     return false;

--- a/firmware-cpp/encoder.h
+++ b/firmware-cpp/encoder.h
@@ -16,7 +16,7 @@ class Encoder {
 public:
     /**
      * @brief Construct a new Encoder object
-     * 
+     *
      * @param pin_a GPIO pin for encoder A (CLK)
      * @param pin_b GPIO pin for encoder B (DT)
      * @param pin_sw GPIO pin for encoder push button (SW)
@@ -24,10 +24,13 @@ public:
      * @param keycode_ccw HID keycode to send on counter-clockwise rotation
      * @param keycode_btn HID keycode to send on button press
      * @param encoder_id Identifier for debug output
+     * @param steps_per_detent Quadrature state changes per physical detent (4 for KY-040, 2 for many bare EC11)
+     * @param reverse_direction Swap CW/CCW if A/B pins are wired in reverse
      */
     Encoder(uint8_t pin_a, uint8_t pin_b, uint8_t pin_sw,
             uint8_t keycode_cw, uint8_t keycode_ccw, uint8_t keycode_btn,
-            uint8_t encoder_id);
+            uint8_t encoder_id, int8_t steps_per_detent = 4,
+            bool reverse_direction = false);
 
     /**
      * @brief Initialize GPIO pins
@@ -60,11 +63,14 @@ private:
     // Encoder state
     uint8_t last_ab_state_;
     int8_t steps_;
+    int8_t steps_per_detent_;
+    bool reverse_direction_;
 
-    // Button state
+    // Button state (first-edge-latch debounce)
     bool last_button_state_;
     bool button_pressed_;
-    uint32_t last_button_time_;
+    uint32_t debounce_start_;   // Time of first edge (0 = no pending debounce)
+    bool debounce_active_;
 
     // Debug
     uint8_t encoder_id_;

--- a/firmware-cpp/main.cpp
+++ b/firmware-cpp/main.cpp
@@ -100,6 +100,15 @@ static const EncoderConfig ENCODER_CONFIGS[4] = {
 // Number of encoders
 constexpr size_t NUM_ENCODERS = 4;
 
+// Number of quadrature state changes per physical detent.
+// KY-040 modules (full-cycle): 4
+// Many bare EC11 encoders (half-cycle): 2
+static constexpr int8_t STEPS_PER_DETENT = 4;
+
+// Set true to swap CW/CCW direction for all encoders.
+// Useful if your encoder's A/B pins are wired in reverse.
+static constexpr bool REVERSE_DIRECTION = false;
+
 // Encoder instances (allocated in main)
 static Encoder* encoders[NUM_ENCODERS];
 
@@ -115,17 +124,38 @@ struct KeyboardReport {
 };
 
 static KeyboardReport keyboard_report;
-static bool key_pending = false;
-static uint8_t pending_keycode = 0;
+
+// Ring buffer for queued key events (prevents dropped keys during rapid rotation)
+static constexpr size_t KEY_QUEUE_SIZE = 8;
+static uint8_t key_queue[KEY_QUEUE_SIZE];
+static size_t key_queue_head = 0;  // Next write position
+static size_t key_queue_tail = 0;  // Next read position
+
+static bool key_queue_empty() {
+    return key_queue_head == key_queue_tail;
+}
+
+static bool key_queue_full() {
+    return ((key_queue_head + 1) % KEY_QUEUE_SIZE) == key_queue_tail;
+}
 
 /**
- * @brief Send a keyboard key press and release
+ * @brief Queue a keyboard key press for sending
  */
 static void send_key(uint8_t keycode) {
     if (keycode == 0) return;
-    
-    pending_keycode = keycode;
-    key_pending = true;
+    if (key_queue_full()) return;  // Queue full — drop incoming key
+
+    key_queue[key_queue_head] = keycode;
+    key_queue_head = (key_queue_head + 1) % KEY_QUEUE_SIZE;
+}
+
+static uint8_t key_queue_peek() {
+    return key_queue[key_queue_tail];
+}
+
+static void key_queue_pop() {
+    key_queue_tail = (key_queue_tail + 1) % KEY_QUEUE_SIZE;
 }
 
 // ============================================================================
@@ -267,21 +297,20 @@ static void hid_task() {
 
     switch (hid_state) {
         case HID_STATE_IDLE:
-            if (key_pending) {
-                // Send key press
+            if (!key_queue_empty()) {
+                // Send key press from front of queue
                 memset(&keyboard_report, 0, sizeof(keyboard_report));
-                keyboard_report.keycodes[0] = pending_keycode;
+                keyboard_report.keycodes[0] = key_queue_peek();
                 tud_hid_keyboard_report(0, 0, keyboard_report.keycodes);
                 hid_state = HID_STATE_KEY_DOWN;
             }
             break;
 
         case HID_STATE_KEY_DOWN:
-            // Send key release
+            // Send key release and consume from queue
             memset(&keyboard_report, 0, sizeof(keyboard_report));
             tud_hid_keyboard_report(0, 0, keyboard_report.keycodes);
-            key_pending = false;
-            pending_keycode = 0;
+            key_queue_pop();
             hid_state = HID_STATE_KEY_UP;
             break;
 
@@ -314,7 +343,7 @@ int main() {
         encoders[i] = new Encoder(
             cfg.pin_a, cfg.pin_b, cfg.pin_sw,
             cfg.key_cw, cfg.key_ccw, cfg.key_btn,
-            i + 1
+            i + 1, STEPS_PER_DETENT, REVERSE_DIRECTION
         );
         encoders[i]->init();
     }

--- a/firmware-cpp/main_generic_hid.cpp
+++ b/firmware-cpp/main_generic_hid.cpp
@@ -102,6 +102,15 @@ static const EncoderPinConfig ENCODER_PIN_CONFIGS[4] = {
 // Number of encoders
 constexpr size_t NUM_ENCODERS = 4;
 
+// Number of quadrature state changes per physical detent.
+// KY-040 modules (full-cycle): 4
+// Many bare EC11 encoders (half-cycle): 2
+static constexpr int8_t STEPS_PER_DETENT = 4;
+
+// Set true to swap CW/CCW direction for all encoders.
+// Useful if your encoder's A/B pins are wired in reverse.
+static constexpr bool REVERSE_DIRECTION = false;
+
 // ============================================================================
 // GENERIC HID ENCODER CLASS
 // ============================================================================
@@ -112,17 +121,22 @@ constexpr size_t NUM_ENCODERS = 4;
  */
 class GenericHidEncoder {
 public:
-    GenericHidEncoder(uint8_t pin_a, uint8_t pin_b, uint8_t pin_sw, uint8_t encoder_id)
+    GenericHidEncoder(uint8_t pin_a, uint8_t pin_b, uint8_t pin_sw,
+                      uint8_t encoder_id, int8_t steps_per_detent = 4,
+                      bool reverse_direction = false)
         : pin_a_(pin_a)
         , pin_b_(pin_b)
         , pin_sw_(pin_sw)
         , encoder_id_(encoder_id)
         , last_ab_state_(0)
         , steps_(0)
+        , steps_per_detent_(steps_per_detent)
+        , reverse_direction_(reverse_direction)
         , accumulated_movement_(0)
         , last_button_state_(true)
         , button_pressed_(false)
-        , last_button_time_(0)
+        , debounce_start_(0)
+        , debounce_active_(false)
     {}
 
     void init() {
@@ -162,31 +176,37 @@ public:
             int8_t direction = TRANSITION_TABLE[index];
 
             if (direction != 0) {
+                if (reverse_direction_) direction = -direction;
                 steps_ += direction;
 
-                // Most encoders have 4 state changes per detent
-                if (steps_ >= 4) {
+                if (steps_ >= steps_per_detent_) {
                     accumulated_movement_++;
                     steps_ = 0;
                     printf("Encoder %d: CW detent\n", encoder_id_);
-                } else if (steps_ <= -4) {
+                } else if (steps_ <= -steps_per_detent_) {
                     accumulated_movement_--;
                     steps_ = 0;
                     printf("Encoder %d: CCW detent\n", encoder_id_);
                 }
+            } else {
+                // Invalid transition (noise) — reset step accumulator
+                steps_ = 0;
             }
 
             last_ab_state_ = current_ab_state;
         }
 
-        // Process button press with debounce
+        // Process button with first-edge-latch debounce
         bool current_button_state = gpio_get(pin_sw_);
         uint32_t current_time = time_us_32();
 
         if (current_button_state != last_button_state_) {
-            if ((current_time - last_button_time_) >= BUTTON_DEBOUNCE_US) {
-                last_button_time_ = current_time;
+            if (!debounce_active_) {
+                debounce_start_ = current_time;
+                debounce_active_ = true;
+            } else if ((current_time - debounce_start_) >= BUTTON_DEBOUNCE_US) {
                 last_button_state_ = current_button_state;
+                debounce_active_ = false;
 
                 if (!current_button_state && !button_pressed_) {
                     button_pressed_ = true;
@@ -196,6 +216,8 @@ public:
                     printf("Encoder %d: Button released\n", encoder_id_);
                 }
             }
+        } else {
+            debounce_active_ = false;
         }
 
         return button_pressed_;
@@ -229,12 +251,15 @@ private:
     // Encoder state
     uint8_t last_ab_state_;
     int8_t steps_;
+    int8_t steps_per_detent_;
+    bool reverse_direction_;
     int16_t accumulated_movement_;
 
-    // Button state
+    // Button state (first-edge-latch debounce)
     bool last_button_state_;
     bool button_pressed_;
-    uint32_t last_button_time_;
+    uint32_t debounce_start_;
+    bool debounce_active_;
 
     // Constants
     static constexpr uint32_t BUTTON_DEBOUNCE_US = 20000;  // 20ms
@@ -404,8 +429,29 @@ uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id,
 // HID TASK
 // ============================================================================
 
+// Cache button states from fast encoder polling for use by rate-limited HID reports
+static uint8_t cached_button_states = 0;
+
+/**
+ * @brief Poll all encoders at full speed (called from main loop).
+ * Encoder rotation and button state are tracked internally;
+ * hid_task() collects accumulated movement at report intervals.
+ */
+static void encoder_poll_task() {
+    uint8_t button_states = 0;
+    for (size_t i = 0; i < NUM_ENCODERS; i++) {
+        if (encoders[i]->update()) {
+            button_states |= (1 << i);
+        }
+    }
+    cached_button_states = button_states;
+}
+
+/**
+ * @brief Send HID reports at a rate-limited interval.
+ * Encoder polling happens separately in encoder_poll_task().
+ */
 static void hid_task() {
-    // Report interval (ms)
     const uint32_t interval_ms = 10;
     static uint32_t start_ms = 0;
 
@@ -414,20 +460,11 @@ static void hid_task() {
 
     if (!tud_hid_ready()) return;
 
-    // Build report
-    uint8_t button_states = 0;
-    for (size_t i = 0; i < NUM_ENCODERS; i++) {
-        bool btn_pressed = encoders[i]->update();
-        if (btn_pressed) {
-            button_states |= (1 << i);
-        }
-    }
-
-    // Get encoder movements
+    // Collect accumulated movement from encoders
     for (size_t i = 0; i < NUM_ENCODERS; i++) {
         current_report.encoder_movement[i] = encoders[i]->get_and_clear_movement();
     }
-    current_report.button_states = button_states;
+    current_report.button_states = cached_button_states;
     current_report.reserved[0] = 0;
     current_report.reserved[1] = 0;
 
@@ -443,9 +480,8 @@ static void hid_task() {
     bool has_change = memcmp(&current_report, &last_report, sizeof(GenericHidReport)) != 0;
 
     if (has_movement || has_change) {
-        // Send report with Report ID 1
         tud_hid_report(1, &current_report, sizeof(GenericHidReport));
-        
+
         if (has_movement) {
             printf("Report: Enc[%d,%d,%d,%d] Btn=0x%02X\n",
                    current_report.encoder_movement[0],
@@ -482,7 +518,7 @@ int main() {
         const auto& cfg = ENCODER_PIN_CONFIGS[i];
         encoders[i] = new GenericHidEncoder(
             cfg.pin_a, cfg.pin_b, cfg.pin_sw,
-            i + 1
+            i + 1, STEPS_PER_DETENT, REVERSE_DIRECTION
         );
         encoders[i]->init();
     }
@@ -499,7 +535,10 @@ int main() {
         // Process USB tasks
         tud_task();
 
-        // Process HID reports
+        // Poll encoders at full speed (not rate-limited)
+        encoder_poll_task();
+
+        // Send HID reports at rate-limited intervals
         hid_task();
     }
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -27,23 +27,39 @@ This directory contains CircuitPython firmware for reading 4 rotary encoders wit
 ### Required Components
 
 - Raspberry Pi Pico (or Pico W)
-- 4× rotary encoder modules (KY-040 style, 5-pin)
+- 4× rotary encoders with push‑button — either type:
+  - **[KY‑040 modules](https://www.amazon.com/Cylewet-Encoder-15%C3%9716-5-Arduino-CYT1062/dp/B06XQTHDRR)** (5‑pin PCB with onboard pull‑ups)
+  - **[Bare encoders](https://www.amazon.com/Cylewet-Encoder-Digital-Potentiometer-Arduino/dp/B07DM2YMT4)** (3+2 pin, no PCB)
 - Breadboard and jumper wires
 - USB micro-B cable
 
 ### Wiring Diagram
 
-| Encoder | A (CLK) | B (DT) | SW (Button) | VCC (+)        | GND       |
-|---------|---------|--------|-------------|----------------|-----------|
-| 1       | GP2     | GP3    | GP4         | 3V3 or NC      | GND       |
-| 2       | GP5     | GP6    | GP7         | 3V3 or NC      | GND       |
-| 3       | GP8     | GP9    | GP10        | 3V3 or NC      | GND       |
-| 4       | GP11    | GP12   | GP13        | 3V3 or NC      | GND       |
+**No external pull‑up resistors are needed** — the firmware enables Pico internal pull‑ups on all encoder pins.
+
+#### KY‑040 Module (5‑pin PCB)
+
+| Encoder | CLK → | DT → | SW → | + (VCC) | GND → |
+|---------|-------|------|------|---------|-------|
+| 1       | GP2   | GP3  | GP4  | NC (leave unconnected) | Pico GND |
+| 2       | GP5   | GP6  | GP7  | NC (leave unconnected) | Pico GND |
+| 3       | GP8   | GP9  | GP10 | NC (leave unconnected) | Pico GND |
+| 4       | GP11  | GP12 | GP13 | NC (leave unconnected) | Pico GND |
+
+#### Bare Encoder (3+2 pin, no PCB)
+
+| Encoder | A (outer pin) → | C (center pin) → | B (outer pin) → | SW1 → | SW2 → |
+|---------|-----------------|------------------|-----------------|-------|-------|
+| 1       | GP2             | Pico GND         | GP3             | GP4   | Pico GND |
+| 2       | GP5             | Pico GND         | GP6             | GP7   | Pico GND |
+| 3       | GP8             | Pico GND         | GP9             | GP10  | Pico GND |
+| 4       | GP11            | Pico GND         | GP12            | GP13  | Pico GND |
 
 **Notes:**
-- All encoder GND pins connect to Pico GND
-- VCC (+) can be connected to 3V3 or left unconnected (firmware uses internal pull-ups)
-- Do NOT connect VCC to 5V (VBUS) as this could damage GPIO pins
+- All encoder GND/common pins connect to Pico GND
+- For KY‑040 modules: leave the + (VCC) pin unconnected — Pico internal pull‑ups provide the HIGH reference
+- For bare encoders: the center pin on the 3‑pin side is common ground; one push‑button pin goes to GPIO, the other to GND
+- Do NOT connect any encoder pin to 5V (VBUS) as this could damage GPIO pins
 
 ## Installation
 

--- a/firmware/code.py
+++ b/firmware/code.py
@@ -39,6 +39,16 @@ KEY_MAPPINGS = [
     {"cw_key": Keycode.F7, "ccw_key": Keycode.F8, "btn_key": Keycode.F12},  # Encoder 4
 ]
 
+# Encoder tuning
+# Number of quadrature state changes per physical detent.
+# KY-040 modules (full-cycle): 4
+# Many bare EC11 encoders (half-cycle): 2
+STEPS_PER_DETENT = 4
+
+# Set True to swap CW/CCW direction for all encoders.
+# Useful if your encoder's A/B pins are wired in reverse.
+REVERSE_DIRECTION = False
+
 # Debounce timing (in seconds)
 BUTTON_DEBOUNCE_TIME = 0.020  # 20ms debounce for buttons
 LOOP_DELAY = 0.001  # 1ms loop delay
@@ -110,16 +120,13 @@ class Encoder:
         self.pin_sw.pull = digitalio.Pull.UP
         
         # Encoder state tracking
-        # Read initial state (inverted because active-low)
         self.last_ab_state = self._read_ab_state()
-        # Accumulated steps - most encoders have 4 state changes per detent
-        # (adjust threshold in update() if your encoder behaves differently)
         self.steps = 0
-        
-        # Button state tracking
+
+        # Button state tracking (first-edge-latch debounce)
         self.last_button_state = self.pin_sw.value  # True = not pressed (pull-up)
         self.button_pressed = False
-        self.last_button_time = time.monotonic()
+        self.debounce_start = None  # Time of first edge, None when stable
     
     def _read_ab_state(self):
         """Read current A/B state as 2-bit value."""
@@ -136,52 +143,58 @@ class Encoder:
         Returns True if an event was sent.
         """
         event_sent = False
-        
+
         # Process encoder rotation
         current_ab_state = self._read_ab_state()
-        
+
         if current_ab_state != self.last_ab_state:
-            # Look up transition in table
             transition = (self.last_ab_state, current_ab_state)
             direction = self.TRANSITION_TABLE.get(transition, 0)
-            
+
             if direction != 0:
+                if REVERSE_DIRECTION:
+                    direction = -direction
                 self.steps += direction
-                
-                # Most encoders have 4 state changes per detent
-                # Send key event when a full detent is completed
-                if self.steps >= 4:
+
+                if self.steps >= STEPS_PER_DETENT:
                     self._send_key(self.cw_key, "CW")
                     self.steps = 0
                     event_sent = True
-                elif self.steps <= -4:
+                elif self.steps <= -STEPS_PER_DETENT:
                     self._send_key(self.ccw_key, "CCW")
                     self.steps = 0
                     event_sent = True
-            
+            else:
+                # Invalid transition (noise) — reset step accumulator
+                self.steps = 0
+
             self.last_ab_state = current_ab_state
-        
-        # Process button press with debounce
+
+        # Process button with first-edge-latch debounce
         current_button_state = self.pin_sw.value
         current_time = time.monotonic()
-        
-        # Button is active-low (pressed = False/low)
+
         if current_button_state != self.last_button_state:
-            if (current_time - self.last_button_time) >= BUTTON_DEBOUNCE_TIME:
-                self.last_button_time = current_time
+            if self.debounce_start is None:
+                # First edge detected — start debounce window
+                self.debounce_start = current_time
+            elif (current_time - self.debounce_start) >= BUTTON_DEBOUNCE_TIME:
+                # Debounce period elapsed — commit the new state
                 self.last_button_state = current_button_state
-                
-                # Detect falling edge (button press)
+                self.debounce_start = None
+
                 if not current_button_state and not self.button_pressed:
                     self.button_pressed = True
                     self._send_key(self.btn_key, "BTN")
                     event_sent = True
-                # Detect rising edge (button release)
                 elif current_button_state and self.button_pressed:
                     self.button_pressed = False
                     if DEBUG_ENABLED:
                         print(f"Encoder {self.encoder_id}: Button released")
-        
+        else:
+            # Signal is stable — clear any pending debounce
+            self.debounce_start = None
+
         return event_sent
     
     def _send_key(self, keycode, event_type):

--- a/firmware/code_generic_hid.py
+++ b/firmware/code_generic_hid.py
@@ -43,6 +43,16 @@ ENCODER_PINS = [
     {"a": board.GP11, "b": board.GP12, "sw": board.GP13}, # Encoder 4
 ]
 
+# Encoder tuning
+# Number of quadrature state changes per physical detent.
+# KY-040 modules (full-cycle): 4
+# Many bare EC11 encoders (half-cycle): 2
+STEPS_PER_DETENT = 4
+
+# Set True to swap CW/CCW direction for all encoders.
+# Useful if your encoder's A/B pins are wired in reverse.
+REVERSE_DIRECTION = False
+
 # Debounce timing (in seconds)
 BUTTON_DEBOUNCE_TIME = 0.020  # 20ms debounce for buttons
 LOOP_DELAY = 0.001  # 1ms loop delay
@@ -109,11 +119,11 @@ class Encoder:
         self.last_ab_state = self._read_ab_state()
         self.steps = 0
         self.accumulated_movement = 0
-        
-        # Button state tracking
+
+        # Button state tracking (first-edge-latch debounce)
         self.last_button_state = self.pin_sw.value  # True = not pressed (pull-up)
         self.button_pressed = False
-        self.last_button_time = time.monotonic()
+        self.debounce_start = None  # Time of first edge, None when stable
     
     def _read_ab_state(self):
         """Read current A/B state as 2-bit value."""
@@ -133,51 +143,54 @@ class Encoder:
         """
         # Process encoder rotation
         current_ab_state = self._read_ab_state()
-        
+
         if current_ab_state != self.last_ab_state:
-            # Look up transition in table
             transition = (self.last_ab_state, current_ab_state)
             direction = self.TRANSITION_TABLE.get(transition, 0)
-            
+
             if direction != 0:
+                if REVERSE_DIRECTION:
+                    direction = -direction
                 self.steps += direction
-                
-                # Most encoders have 4 state changes per detent
-                # Accumulate movement when a full detent is completed
-                if self.steps >= 4:
+
+                if self.steps >= STEPS_PER_DETENT:
                     self.accumulated_movement += 1
                     self.steps = 0
                     if DEBUG_ENABLED:
                         print(f"Encoder {self.encoder_id}: CW detent")
-                elif self.steps <= -4:
+                elif self.steps <= -STEPS_PER_DETENT:
                     self.accumulated_movement -= 1
                     self.steps = 0
                     if DEBUG_ENABLED:
                         print(f"Encoder {self.encoder_id}: CCW detent")
-            
+            else:
+                # Invalid transition (noise) — reset step accumulator
+                self.steps = 0
+
             self.last_ab_state = current_ab_state
-        
-        # Process button press with debounce
+
+        # Process button with first-edge-latch debounce
         current_button_state = self.pin_sw.value
         current_time = time.monotonic()
-        
-        # Button is active-low (pressed = False/low)
+
         if current_button_state != self.last_button_state:
-            if (current_time - self.last_button_time) >= BUTTON_DEBOUNCE_TIME:
-                self.last_button_time = current_time
+            if self.debounce_start is None:
+                self.debounce_start = current_time
+            elif (current_time - self.debounce_start) >= BUTTON_DEBOUNCE_TIME:
                 self.last_button_state = current_button_state
-                
-                # Detect falling edge (button press)
+                self.debounce_start = None
+
                 if not current_button_state and not self.button_pressed:
                     self.button_pressed = True
                     if DEBUG_ENABLED:
                         print(f"Encoder {self.encoder_id}: Button pressed")
-                # Detect rising edge (button release)
                 elif current_button_state and self.button_pressed:
                     self.button_pressed = False
                     if DEBUG_ENABLED:
                         print(f"Encoder {self.encoder_id}: Button released")
-        
+        else:
+            self.debounce_start = None
+
         return self.button_pressed
     
     def get_and_clear_movement(self):


### PR DESCRIPTION
## Summary
- Add documentation and wiring diagrams for bare encoders (3+2 pin, no PCB) alongside existing KY-040 module support
- Fix 6 firmware issues found during code review for bare encoder compatibility:
  - Add `STEPS_PER_DETENT` config (default 4 for KY-040, 2 for half-cycle bare EC11)
  - Reset quadrature step accumulator on invalid transitions (prevents phantom rotations from noise)
  - Move encoder polling to main loop in `main_generic_hid.cpp` (was only 100Hz, now full speed)
  - Replace single pending keycode with 8-entry ring buffer in `main.cpp` (prevents dropped keys)
  - Switch to first-edge-latch debounce (more reliable with bare encoders)
  - Add `REVERSE_DIRECTION` config for swapped A/B wiring

## Test plan
- [ ] Verify KY-040 modules still work identically (no behavioral regressions)
- [ ] Verify bare encoder (e.g., Cylewet CYT1100) wiring per new diagrams
- [ ] Test `STEPS_PER_DETENT = 2` with half-cycle bare encoders
- [ ] Test `REVERSE_DIRECTION = True` corrects swapped A/B wiring
- [ ] Verify rapid rotation no longer drops key events (main.cpp ring buffer)
- [ ] Verify generic HID mode captures fast rotation (main_generic_hid.cpp polling fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)