### PR TITLE
Add runtime configuration for Generic HID mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ compile_commands.json
 
 # CodeQL artifacts
 _codeql_detected_source_root
+
+# Git worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ RotaryUsb supports two HID modes:
 - Applications read raw encoder position and button states directly
 - Events are exclusive to applications that open the device
 - Better for precise control and custom integrations
+- **Runtime configurable:** Encoder bounds, step size, acceleration, and wrapping can be configured at runtime from the Windows app and saved to device flash
 
 ### Firmware Options
 

--- a/docs/superpowers/specs/2026-03-21-runtime-config-design.md
+++ b/docs/superpowers/specs/2026-03-21-runtime-config-design.md
@@ -1,0 +1,303 @@
+# Runtime Configuration for Generic HID Mode
+
+## Overview
+
+Add runtime configuration to the RotaryUsb Generic HID mode, enabling host applications to configure encoder behavior (min/max values, step size, acceleration) without recompiling firmware. Encoders shift from relative movement reporting to absolute position tracking with configurable bounds.
+
+Scope: Generic HID mode only (CircuitPython and C++ firmware, Windows console app). Keyboard HID mode is unchanged.
+
+## Requirements
+
+1. Each encoder tracks an absolute position (`int32`) with configurable min/max bounds
+2. Step size per detent is configurable per encoder (`int32`, supports MHz-range values)
+3. Three configurable acceleration tiers per encoder: faster rotation applies larger step multipliers
+4. Encoders can wrap around at bounds or clamp, configurable per encoder
+5. Direction (CW/CCW) is reversible per encoder
+6. Configuration is sent from host to device via HID Output Reports at runtime
+7. Configuration persists to device flash and loads on boot
+8. Host verifies config acceptance by reading back after writing
+9. Windows console app provides an interactive config menu with built-in presets
+
+## HID Report Protocol
+
+All offset tables describe payload bytes **after** the Report ID byte. The Report ID is transmitted on the wire but is not included in offset counts. In CircuitPython, `send_report()` prepends the Report ID automatically; `get_last_received_report()` returns payload only. In TinyUSB (C++), the Report ID is passed as a separate parameter in callbacks.
+
+### Why Output Reports instead of Feature Reports
+
+HID Feature Reports (GET/SET) travel over the USB control endpoint (EP0). CircuitPython's `usb_hid` module does not expose Feature Report access to Python code — it only supports `send_report()` (Input Reports) and `get_last_received_report()` (Output Reports). To keep both firmware implementations using the same protocol, all host-to-device communication uses Output Reports and all device-to-host communication uses Input Reports. The C++ firmware (TinyUSB) supports both mechanisms, but uses Output/Input Reports for protocol consistency.
+
+### Input Report (ID 0x01) — 21 bytes, Device to Host
+
+Reports current encoder positions, button states, and active acceleration tiers. Sent continuously at the report interval (~10ms).
+
+| Offset | Type | Description |
+|--------|------|-------------|
+| 0-3 | int32 LE | Encoder 1 absolute position |
+| 4-7 | int32 LE | Encoder 2 absolute position |
+| 8-11 | int32 LE | Encoder 3 absolute position |
+| 12-15 | int32 LE | Encoder 4 absolute position |
+| 16 | uint8 | Button states (bit 0-3 = buttons 1-4, 1 = pressed) |
+| 17 | uint8 | Acceleration tier used for each encoder's most recent detent, packed: enc1 = bits 0-1, enc2 = bits 2-3, enc3 = bits 4-5, enc4 = bits 6-7. Values: 0 = normal, 1 = tier 1, 2 = tier 2, 3 = tier 3. Initialized to 0 on boot and on position reset. Value remains set until the next detent event on that encoder. |
+| 18-20 | uint8[3] | Reserved (0x00) |
+
+### Input Report (ID 0x02) — 106 bytes, Device to Host
+
+Config readback. Sent once by the device in response to a "read config" command (Output Report ID 0x03, command 0x04). The host uses this to verify config was accepted after writing.
+
+Layout is identical to the Output Report ID 0x02 config structure defined below.
+
+### Output Report (ID 0x02) — 106 bytes, Host to Device
+
+Full device configuration. Host writes to update config. Device applies immediately if validation passes; retains current config if validation fails.
+
+#### Header (2 bytes)
+
+| Offset | Type | Description |
+|--------|------|-------------|
+| 0 | uint8 | Config version (0x01) |
+| 1 | uint8 | Global flags. Bit 0: steps_per_detent mode (0 = 4 steps/detent for KY-040, 1 = 2 steps/detent for bare EC11). Bits 1-7: reserved |
+
+#### Per-Encoder Config (26 bytes each, offsets relative to encoder block start)
+
+Four encoder config blocks at absolute offsets 2, 28, 54, 80.
+
+| Offset | Type | Description |
+|--------|------|-------------|
+| 0-3 | int32 LE | min_value — minimum encoder position |
+| 4-7 | int32 LE | max_value — maximum encoder position |
+| 8-11 | int32 LE | step_size — base value change per detent |
+| 12 | uint8 | wrap — 0 = clamp at min/max, 1 = wrap around |
+| 13 | uint8 | reverse — 0 = normal direction, 1 = swap CW/CCW |
+| 14-15 | uint16 LE | accel_tier1_threshold_ms — detent interval below which tier 1 activates |
+| 16-17 | uint16 LE | accel_tier1_multiplier — step_size multiplier for tier 1 |
+| 18-19 | uint16 LE | accel_tier2_threshold_ms |
+| 20-21 | uint16 LE | accel_tier2_multiplier |
+| 22-23 | uint16 LE | accel_tier3_threshold_ms |
+| 24-25 | uint16 LE | accel_tier3_multiplier |
+
+### Output Report (ID 0x03) — 2 bytes, Host to Device
+
+Device commands.
+
+| Offset | Type | Description |
+|--------|------|-------------|
+| 0 | uint8 | Command: 0x01 = save config to flash, 0x02 = reset to defaults, 0x03 = reset all positions to min_value, 0x04 = send current config as Input Report ID 0x02 |
+| 1 | uint8 | Reserved (0x00) |
+
+## Encoder Processing Pipeline
+
+Each encoder processes detents through this pipeline:
+
+```
+GPIO read
+  -> Quadrature decode (existing)
+  -> Measure time since last detent
+  -> Select acceleration tier based on time
+  -> Compute effective_step = step_size * multiplier (as int64, then clamp to int32)
+  -> Update position: position += direction * effective_step
+  -> Clamp to [min_value, max_value] or wrap
+  -> Store position for next Input Report
+```
+
+### Acceleration Tier Selection
+
+On each detent:
+1. Compute `interval_ms` = time since previous detent
+2. Check tiers in order from fastest (tier 3) to slowest (tier 1):
+   - If `interval_ms < tier3_threshold_ms` and tier 3 is enabled (threshold > 0): use tier 3 multiplier
+   - Else if `interval_ms < tier2_threshold_ms` and tier 2 is enabled (threshold > 0): use tier 2 multiplier
+   - Else if `interval_ms < tier1_threshold_ms` and tier 1 is enabled (threshold > 0): use tier 1 multiplier
+   - Else: use multiplier of 1 (normal speed)
+3. A tier is disabled when its threshold is 0. Disabled tiers are simply skipped in the check order above. This means if tier 2 is disabled but tiers 1 and 3 are enabled, the algorithm checks tier 3 first, skips tier 2, then checks tier 1.
+4. Store the selected tier index (0-3) in the active tier field of the Input Report. This value persists until the next detent event on that encoder.
+
+### Effective Step Computation
+
+`effective_step = (int64)step_size * (int64)multiplier`
+
+The multiplication is performed in 64-bit to avoid overflow. The result is then clamped to `INT32_MIN..INT32_MAX` before being applied to the position. This ensures that large `step_size` values (MHz-range) combined with large multipliers do not produce undefined behavior.
+
+### Position Clamping and Wrapping
+
+If `wrap == false`:
+```
+position = clamp(position, min_value, max_value)
+```
+
+If `wrap == true`:
+```
+range = (int64)max_value - (int64)min_value + 1
+if position > max_value:
+    position = min_value + ((position - min_value) % range)
+if position < min_value:
+    position = max_value - ((min_value - 1 - position) % range)
+```
+
+The `range` computation uses 64-bit arithmetic to avoid overflow when `max_value - min_value` spans a large portion of the int32 range.
+
+### Initial Position
+
+On boot (whether loading from flash or using factory defaults) and on the "reset positions" command (0x03), all encoder positions are initialized to `min_value`.
+
+## Default Configuration
+
+### General Purpose (factory defaults)
+
+| Parameter | Value |
+|-----------|-------|
+| min_value | 0 |
+| max_value | 100 |
+| step_size | 1 |
+| wrap | false |
+| reverse | false |
+| Tier 1 | threshold: 150ms, multiplier: 5 |
+| Tier 2 | threshold: 80ms, multiplier: 15 |
+| Tier 3 | threshold: 40ms, multiplier: 50 |
+
+### Built-in Presets (Windows App)
+
+**Radio Tuner (kHz):**
+min=88000, max=108000, step=100, wrap=true, reverse=false.
+Tiers: 150ms/10x, 80ms/100x, 40ms/1000x.
+
+**Audio Mixer (%):**
+min=0, max=100, step=1, wrap=false, reverse=false.
+Tiers: 150ms/2x, 80ms/5x, 40ms/10x.
+
+**Fine Control:**
+min=0, max=10000, step=1, wrap=false, reverse=false.
+Tiers: 150ms/5x, 80ms/25x, 40ms/100x.
+
+## Config Validation (Device-Side)
+
+The device validates incoming config before applying. If validation fails, the current config is retained unchanged. The host detects rejection by sending command 0x04 ("read config") and comparing the returned Input Report ID 0x02 against what was sent.
+
+Rules:
+- `min_value < max_value`
+- `step_size > 0`
+- Enabled tier thresholds must be strictly descending: among all tiers where threshold > 0, `tier1_threshold > tier2_threshold > tier3_threshold`. Validation checks only pairs where both tiers are enabled. Example: if tier 2 is disabled (threshold=0) but tiers 1 and 3 are enabled, the rule checks `tier1_threshold > tier3_threshold`.
+- Enabled tier multipliers must be strictly ascending: among all tiers where threshold > 0, `tier1_multiplier < tier2_multiplier < tier3_multiplier`. Same pairing rules as thresholds.
+- A tier with threshold = 0 is disabled. Its multiplier value is ignored during validation.
+- Config version byte must match expected version (0x01)
+
+## Config Persistence
+
+### CircuitPython
+
+`boot.py` calls `storage.remount("/", readonly=False)` to allow code to write to the filesystem. This makes the CIRCUITPY drive read-only from the host PC, which is acceptable since all config is managed via HID Output Reports.
+
+Config is stored as `config.bin` on the CIRCUITPY filesystem — a raw 106-byte binary dump matching the Output Report ID 0x02 layout. Validity is checked by verifying the config version byte (0x01) and running the same validation rules used for incoming config.
+
+On boot:
+1. If `config.bin` exists, read it, and if it passes validation, load it
+2. Otherwise, use factory defaults
+3. Set all encoder positions to `min_value`
+
+On save command (0x01):
+1. Write current config to `config.bin`
+
+### C++
+
+Config is stored in the last flash sector (4096 bytes) of the Pico's onboard flash using `hardware_flash` API.
+
+Layout in flash: 4-byte magic number (`0x52554342` = "RUCB"), followed by the 106-byte config, followed by a 2-byte CRC16-CCITT (polynomial 0x1021, initial value 0xFFFF, no output reflection).
+
+On boot:
+1. Read flash sector, verify magic number and CRC16-CCITT
+2. If valid, load config and run validation rules
+3. If either CRC or validation fails, use factory defaults
+4. Set all encoder positions to `min_value`
+
+On save command (0x01):
+1. Compute CRC16-CCITT over the 106-byte config
+2. Erase sector, write magic + config + CRC
+
+Flash writes briefly disable interrupts (~2ms). At most one detent may be slightly delayed.
+
+## File Changes
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `firmware/boot.py` | New HID descriptor with Input Report (positions) + Output Reports (config write, commands). Add `storage.remount` for filesystem write access. Two Input Report IDs (0x01 for positions, 0x02 for config readback). |
+| `firmware/code_generic_hid.py` | New Encoder class with position tracking, acceleration, config struct. Output Report handler for config write and commands. Config readback via Input Report ID 0x02. Flash persistence via filesystem. New Input Report format (int32 positions). |
+| `firmware-cpp/main_generic_hid.cpp` | Same encoder changes as CircuitPython. Updated GenericHidEncoder class. TinyUSB `tud_hid_set_report_cb` handles Output Reports for config/commands. Flash persistence via `hardware_flash`. New HID report descriptor with Output Reports. |
+| `firmware-cpp/tusb_config.h` | Increase `CFG_TUD_HID_EP_BUFSIZE` from 16 to 128. This buffer sizes the interrupt IN endpoint used for Input Reports. Input Report ID 0x01 is 21 bytes, but Input Report ID 0x02 (config readback) is 106 bytes payload + 1 byte Report ID = 107 bytes on the wire, so the buffer must be at least 107 (128 for alignment). Output Reports (config write, commands) are received via EP0 SET_REPORT control transfers. Although the 107-byte config exceeds the EP0 packet size of 64 bytes, TinyUSB's control transfer state machine reassembles multi-packet payloads and delivers the complete buffer to `tud_hid_set_report_cb` in a single call. No change to `CFG_TUD_ENDPOINT0_SIZE` is needed. |
+| `firmware-cpp/CMakeLists.txt` | Add `hardware_flash` to `target_link_libraries` for flash persistence API. |
+| `windows-example/Program.cs` | Parse new Input Report format (int32 positions). Send Output Reports for config write and commands. Read config via Input Report ID 0x02. Interactive config menu. Built-in presets. |
+
+### Unchanged Files
+
+| File | Reason |
+|------|--------|
+| `firmware/code.py` | Keyboard HID mode — out of scope |
+| `firmware-cpp/encoder.h` | Used by keyboard mode only |
+| `firmware-cpp/encoder.cpp` | Used by keyboard mode only |
+| `firmware-cpp/main.cpp` | Keyboard HID mode — out of scope |
+
+## Windows Console App UX
+
+### Main Menu
+
+```
+RotaryUsb Configuration
+========================
+Device connected: VID:0xCAFE PID:0x4005
+
+Current encoder values:
+  Enc1:       50  [0 - 100, step=1]
+  Enc2:   94200  [88000 - 108000, step=100]
+  Enc3:        0  [0 - 255, step=1]
+  Enc4:       75  [0 - 100, step=1]
+
+[M] Monitor - Live display of encoder values
+[C] Configure encoder
+[S] Save config to device flash
+[D] Reset to defaults
+[R] Reset positions
+[Q] Quit
+```
+
+### Configure Encoder Submenu
+
+```
+Configure Encoder
+=================
+Select encoder [1-4]: 2
+
+Encoder 2 current config:
+  Min: 88000  Max: 108000  Step: 100  Wrap: Yes  Reverse: No
+  Tier 1: <150ms -> 10x    Tier 2: <80ms -> 100x    Tier 3: <40ms -> 1000x
+
+[1] Min value          [5] Reverse
+[2] Max value          [6] Tier 1 (threshold, multiplier)
+[3] Step size          [7] Tier 2
+[4] Wrap on/off        [8] Tier 3
+[A] Apply (send to device)
+[P] Load preset (General / Radio Tuner / Audio Mixer / Fine Control)
+[B] Back
+```
+
+### Live Monitor
+
+```
+Live Monitor (press any key to return)
+=======================================
+Enc1:       50  [0-100]
+Enc2:   94,200  [88000-108000]  ** Tier 2
+Enc3:        0  [0-255]
+Enc4:       75  [0-100]         * Tier 1
+
+Buttons: [ ] [ ] [X] [ ]
+```
+
+## Error Handling
+
+- **Invalid config from host:** Device keeps current config. Host detects rejection by sending command 0x04 to request config readback and comparing against what was sent.
+- **Corrupt flash on boot:** Detected via config version byte mismatch (CircuitPython) or magic number / CRC16-CCITT failure (C++). Falls back to factory defaults.
+- **Device unplugged mid-config-write:** No harm — runtime config was applied but not persisted. Next boot uses previous saved config or defaults.
+- **Flash write during rotation:** Brief interrupt disable (~2ms) may delay at most one detent. Acceptable.
+- **Host sends unknown command ID:** Device ignores it.
+- **Host sends wrong-size Output Report:** USB HID layer rejects it before firmware sees it.
+- **Effective step overflow:** Multiplication uses 64-bit intermediate; result is clamped to int32 range before applying to position.

--- a/firmware-cpp/CMakeLists.txt
+++ b/firmware-cpp/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(rotary_usb
     pico_stdlib
     tinyusb_device
     tinyusb_board
+    hardware_flash
 )
 
 # Enable USB output, disable UART output

--- a/firmware-cpp/CMakeLists.txt
+++ b/firmware-cpp/CMakeLists.txt
@@ -11,6 +11,9 @@ set(CMAKE_CXX_STANDARD 17)
 # Initialize the Raspberry Pi Pico SDK
 pico_sdk_init()
 
+# main.cpp is the active firmware entry point.
+# For Generic HID mode: copy main_generic_hid.cpp to main.cpp before building.
+# For Keyboard HID mode: use the original main.cpp (default).
 add_executable(rotary_usb
     main.cpp
     encoder.cpp

--- a/firmware-cpp/README.md
+++ b/firmware-cpp/README.md
@@ -341,18 +341,17 @@ make -j4
 
 ### HID Report Format (Generic HID Mode)
 
-When using Generic HID mode, the device sends 8-byte reports:
+When using Generic HID mode, the device sends 21-byte position reports (Input Report ID 0x01):
 
-| Byte | Description | Range |
-|------|-------------|-------|
-| 0 | Report ID | Always 0x01 |
-| 1 | Encoder 1 movement | -127 to +127 (signed, positive = CW) |
-| 2 | Encoder 2 movement | -127 to +127 (signed, positive = CW) |
-| 3 | Encoder 3 movement | -127 to +127 (signed, positive = CW) |
-| 4 | Encoder 4 movement | -127 to +127 (signed, positive = CW) |
-| 5 | Button states | Bit 0-3: Buttons 1-4 (1 = pressed) |
-| 6 | Reserved | 0x00 |
-| 7 | Reserved | 0x00 |
+| Offset | Type | Description |
+|--------|------|-------------|
+| 0-3 | int32 LE | Encoder 1 absolute position |
+| 4-7 | int32 LE | Encoder 2 absolute position |
+| 8-11 | int32 LE | Encoder 3 absolute position |
+| 12-15 | int32 LE | Encoder 4 absolute position |
+| 16 | uint8 | Button states (bit 0-3 = buttons 1-4) |
+| 17 | uint8 | Active acceleration tiers (packed 2-bit per encoder) |
+| 18-20 | uint8[3] | Reserved (0x00) |
 
 ### USB Identifiers (Generic HID Mode)
 
@@ -370,3 +369,22 @@ To read the Generic HID reports from your application:
 3. **Cross-platform:** Use hidapi bindings for your language
 
 See the `windows-example/` directory for a C# example using HidLibrary.
+
+### Runtime Configuration
+
+Generic HID mode supports runtime configuration from the host application. The device uses Output Reports for host-to-device communication:
+
+| Report | Direction | Size | Description |
+|--------|-----------|------|-------------|
+| Input ID 0x01 | Device → Host | 21 bytes | Absolute positions + buttons + tiers |
+| Input ID 0x02 | Device → Host | 106 bytes | Config readback |
+| Output ID 0x02 | Host → Device | 106 bytes | Full config write |
+| Output ID 0x03 | Host → Device | 2 bytes | Commands |
+
+#### Flash Persistence
+
+Config is stored in the last flash sector (4096 bytes) with a magic number (`0x52554342`), 106-byte config payload, and CRC16-CCITT checksum. The `hardware_flash` library is used for flash read/write.
+
+#### Build Dependencies
+
+The runtime config feature adds `hardware_flash` to the link dependencies in `CMakeLists.txt` and increases `CFG_TUD_HID_EP_BUFSIZE` from 16 to 128 bytes in `tusb_config.h`.

--- a/firmware-cpp/main_generic_hid.cpp
+++ b/firmware-cpp/main_generic_hid.cpp
@@ -117,6 +117,7 @@ static bool validate_encoder_config(const EncoderConfig& enc) {
 
     for (size_t i = 0; i < NUM_TIERS; i++) {
         if (enc.tiers[i].threshold_ms > 0) {
+            if (enc.tiers[i].multiplier == 0) return false;
             if (has_prev) {
                 if (enc.tiers[i].threshold_ms >= prev_threshold) return false;
                 if (enc.tiers[i].multiplier <= prev_multiplier) return false;
@@ -259,10 +260,12 @@ static const uint8_t hid_report_descriptor[] = {
     // ---- Input Report ID 0x01: Encoder Positions (21 bytes) ----
     0x85, 0x01,        //   Report ID (1)
 
-    // 4 encoder positions as 32-bit values (16 bytes)
+    // 4 encoder positions as 32-bit values (16 raw bytes)
+    // Logical min/max are nominal; actual int32 values are parsed by the host
+    // app from the raw vendor-defined bytes, not by the HID driver.
     0x09, 0x02,        //   Usage (Vendor Usage 2 - Encoder Positions)
-    0x16, 0x00, 0x80,  //   Logical Minimum (-32768)
-    0x26, 0xFF, 0x7F,  //   Logical Maximum (32767)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
     0x75, 0x08,        //   Report Size (8 bits)
     0x95, 0x10,        //   Report Count (16 bytes = 4x int32)
     0x81, 0x02,        //   Input (Data, Variable, Absolute)
@@ -481,7 +484,7 @@ private:
     uint8_t encoder_id_;
 
     uint8_t last_ab_state_;
-    int8_t steps_;
+    int16_t steps_;  // int16 to prevent overflow under rapid bounce noise
 
     // Absolute position tracking
     int32_t position_;
@@ -516,6 +519,7 @@ static GenericHidEncoder* encoders[NUM_ENCODERS];
 static PositionReport current_report;
 static PositionReport last_report;
 static bool pending_config_readback = false;
+static bool pending_save = false;
 
 // ============================================================================
 // TINYUSB DESCRIPTORS AND CALLBACKS
@@ -627,7 +631,7 @@ void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id,
         // Command
         uint8_t command = buffer[0];
         if (command == CMD_SAVE_CONFIG) {
-            save_config_to_flash();
+            pending_save = true;  // Defer to main loop — flash write requires non-interrupt context
         } else if (command == CMD_RESET_DEFAULTS) {
             device_config = factory_default_config();
             int8_t spd = (device_config.global_flags & 0x01) ? 2 : 4;
@@ -747,6 +751,13 @@ int main() {
 
     while (true) {
         tud_task();
+
+        // Deferred flash write — must run outside USB interrupt context
+        if (pending_save) {
+            pending_save = false;
+            save_config_to_flash();
+        }
+
         encoder_poll_task();
         hid_task();
     }

--- a/firmware-cpp/main_generic_hid.cpp
+++ b/firmware-cpp/main_generic_hid.cpp
@@ -4,22 +4,18 @@
 /**
  * @file main_generic_hid.cpp
  * @brief C++ firmware for Raspberry Pi Pico - Generic HID Mode
- * 
- * This firmware reads 4 rotary encoders with push buttons and sends
- * raw USB HID reports using a vendor-defined HID descriptor.
- * This allows applications to read encoder data directly without
- * keyboard event interception.
- * 
- * HID REPORT FORMAT (8 bytes total):
- *   Byte 0: Report ID (0x01)
- *   Byte 1: Encoder 1 movement (signed: -127 to +127, positive=CW)
- *   Byte 2: Encoder 2 movement (signed: -127 to +127, positive=CW)
- *   Byte 3: Encoder 3 movement (signed: -127 to +127, positive=CW)
- *   Byte 4: Encoder 4 movement (signed: -127 to +127, positive=CW)
- *   Byte 5: Button states (bit 0=Btn1, bit 1=Btn2, bit 2=Btn3, bit 3=Btn4)
- *   Byte 6: Reserved (0x00)
- *   Byte 7: Reserved (0x00)
- * 
+ *        Runtime Configuration with Absolute Position Tracking
+ *
+ * Reads 4 rotary encoders with push buttons and sends absolute position data
+ * via USB HID reports. Supports runtime configuration from the host via
+ * Output Reports, with flash persistence.
+ *
+ * HID REPORT FORMAT:
+ *   Input Report ID 0x01 (21 bytes): Encoder positions + buttons + tiers
+ *   Input Report ID 0x02 (106 bytes): Config readback
+ *   Output Report ID 0x02 (106 bytes): Config write
+ *   Output Report ID 0x03 (2 bytes): Device commands
+ *
  * BUILD INSTRUCTIONS:
  *   1. Rename this file to main.cpp (backup the original)
  *   2. Rebuild the firmware: cmake .. && make
@@ -28,33 +24,250 @@
 
 #include <cstdio>
 #include <cstring>
+#include <cstdint>
 #include "pico/stdlib.h"
 #include "pico/bootrom.h"
+#include "hardware/flash.h"
+#include "hardware/sync.h"
 #include "tusb.h"
 #include "encoder.h"
+
+// ============================================================================
+// CONFIG DATA STRUCTURES
+// ============================================================================
+
+static constexpr uint8_t CONFIG_VERSION = 0x01;
+static constexpr size_t NUM_ENCODERS = 4;
+static constexpr size_t NUM_TIERS = 3;
+static constexpr size_t FULL_CONFIG_SIZE = 106;
+
+struct TierConfig {
+    uint16_t threshold_ms;
+    uint16_t multiplier;
+} __attribute__((packed));
+
+struct EncoderConfig {
+    int32_t min_value;
+    int32_t max_value;
+    int32_t step_size;
+    uint8_t wrap;
+    uint8_t reverse;
+    TierConfig tiers[NUM_TIERS];
+} __attribute__((packed));
+
+struct DeviceConfig {
+    uint8_t version;
+    uint8_t global_flags;
+    EncoderConfig encoders[NUM_ENCODERS];
+} __attribute__((packed));
+
+static_assert(sizeof(TierConfig) == 4, "TierConfig must be 4 bytes");
+static_assert(sizeof(EncoderConfig) == 26, "EncoderConfig must be 26 bytes");
+static_assert(sizeof(DeviceConfig) == FULL_CONFIG_SIZE, "DeviceConfig must be 106 bytes");
+
+// Input Report: absolute positions + buttons + tiers
+struct PositionReport {
+    int32_t positions[NUM_ENCODERS];
+    uint8_t button_states;
+    uint8_t active_tiers;  // packed 2-bit fields
+    uint8_t reserved[3];
+} __attribute__((packed));
+
+static_assert(sizeof(PositionReport) == 21, "PositionReport must be 21 bytes");
+
+// Command codes (Output Report ID 0x03)
+static constexpr uint8_t CMD_SAVE_CONFIG     = 0x01;
+static constexpr uint8_t CMD_RESET_DEFAULTS  = 0x02;
+static constexpr uint8_t CMD_RESET_POSITIONS = 0x03;
+static constexpr uint8_t CMD_READ_CONFIG     = 0x04;
+
+// ============================================================================
+// FACTORY DEFAULTS
+// ============================================================================
+
+static DeviceConfig factory_default_config() {
+    DeviceConfig cfg;
+    cfg.version = CONFIG_VERSION;
+    cfg.global_flags = 0;
+    for (size_t i = 0; i < NUM_ENCODERS; i++) {
+        cfg.encoders[i].min_value = 0;
+        cfg.encoders[i].max_value = 100;
+        cfg.encoders[i].step_size = 1;
+        cfg.encoders[i].wrap = 0;
+        cfg.encoders[i].reverse = 0;
+        cfg.encoders[i].tiers[0] = {150, 5};
+        cfg.encoders[i].tiers[1] = {80, 15};
+        cfg.encoders[i].tiers[2] = {40, 50};
+    }
+    return cfg;
+}
+
+// ============================================================================
+// CONFIG VALIDATION
+// ============================================================================
+
+static bool validate_encoder_config(const EncoderConfig& enc) {
+    if (enc.min_value >= enc.max_value) return false;
+    if (enc.step_size <= 0) return false;
+
+    // Collect enabled tiers and validate ordering
+    uint16_t prev_threshold = 0;
+    uint16_t prev_multiplier = 0;
+    bool has_prev = false;
+
+    for (size_t i = 0; i < NUM_TIERS; i++) {
+        if (enc.tiers[i].threshold_ms > 0) {
+            if (has_prev) {
+                if (enc.tiers[i].threshold_ms >= prev_threshold) return false;
+                if (enc.tiers[i].multiplier <= prev_multiplier) return false;
+            }
+            prev_threshold = enc.tiers[i].threshold_ms;
+            prev_multiplier = enc.tiers[i].multiplier;
+            has_prev = true;
+        }
+    }
+    return true;
+}
+
+static bool validate_config(const DeviceConfig& cfg) {
+    if (cfg.version != CONFIG_VERSION) return false;
+    for (size_t i = 0; i < NUM_ENCODERS; i++) {
+        if (!validate_encoder_config(cfg.encoders[i])) return false;
+    }
+    return true;
+}
+
+// ============================================================================
+// ACCELERATION AND POSITION LOGIC
+// ============================================================================
+
+struct TierResult {
+    uint8_t tier_index;  // 0 = normal, 1-3 = acceleration tier
+    uint16_t multiplier;
+};
+
+static TierResult select_acceleration_tier(uint32_t interval_ms, const TierConfig tiers[NUM_TIERS]) {
+    // Check from fastest (tier 3) to slowest (tier 1)
+    for (int i = NUM_TIERS - 1; i >= 0; i--) {
+        if (tiers[i].threshold_ms > 0 && interval_ms < tiers[i].threshold_ms) {
+            return {static_cast<uint8_t>(i + 1), tiers[i].multiplier};
+        }
+    }
+    return {0, 1};
+}
+
+static int32_t compute_effective_step(int32_t step_size, uint16_t multiplier) {
+    int64_t result = (int64_t)step_size * (int64_t)multiplier;
+    if (result > INT32_MAX) return INT32_MAX;
+    if (result < INT32_MIN) return INT32_MIN;
+    return (int32_t)result;
+}
+
+static int32_t clamp_position(int32_t position, int32_t min_value, int32_t max_value, bool wrap) {
+    if (!wrap) {
+        if (position < min_value) return min_value;
+        if (position > max_value) return max_value;
+        return position;
+    }
+
+    int64_t range = (int64_t)max_value - (int64_t)min_value + 1;
+    if (position > max_value) {
+        int64_t offset = (int64_t)position - (int64_t)min_value;
+        position = (int32_t)(min_value + (offset % range));
+    } else if (position < min_value) {
+        int64_t offset = (int64_t)min_value - 1 - (int64_t)position;
+        position = (int32_t)(max_value - (offset % range));
+    }
+    return position;
+}
+
+// ============================================================================
+// FLASH PERSISTENCE
+// ============================================================================
+
+// Flash storage at last sector
+#define FLASH_CONFIG_OFFSET (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE)
+#define FLASH_MAGIC 0x52554342  // "RUCB"
+
+struct FlashHeader {
+    uint32_t magic;
+    DeviceConfig config;
+    uint16_t crc;
+} __attribute__((packed));
+
+static uint16_t crc16_ccitt(const uint8_t* data, size_t len) {
+    uint16_t crc = 0xFFFF;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= (uint16_t)data[i] << 8;
+        for (int j = 0; j < 8; j++) {
+            if (crc & 0x8000)
+                crc = (crc << 1) ^ 0x1021;
+            else
+                crc <<= 1;
+        }
+    }
+    return crc;
+}
+
+// Global device config
+static DeviceConfig device_config;
+
+static void load_config_from_flash() {
+    const uint8_t* flash_addr = (const uint8_t*)(XIP_BASE + FLASH_CONFIG_OFFSET);
+    const FlashHeader* header = (const FlashHeader*)flash_addr;
+    if (header->magic == FLASH_MAGIC) {
+        uint16_t computed_crc = crc16_ccitt(
+            (const uint8_t*)&header->config, sizeof(DeviceConfig));
+        if (computed_crc == header->crc && validate_config(header->config)) {
+            memcpy(&device_config, &header->config, sizeof(DeviceConfig));
+            printf("Config loaded from flash\n");
+            return;
+        }
+    }
+    device_config = factory_default_config();
+    printf("Using factory default config\n");
+}
+
+static void save_config_to_flash() {
+    FlashHeader header;
+    header.magic = FLASH_MAGIC;
+    memcpy(&header.config, &device_config, sizeof(DeviceConfig));
+    header.crc = crc16_ccitt(
+        (const uint8_t*)&header.config, sizeof(DeviceConfig));
+
+    // Pad to FLASH_PAGE_SIZE (256 bytes)
+    uint8_t page[FLASH_PAGE_SIZE] = {0};
+    memcpy(page, &header, sizeof(FlashHeader));
+
+    uint32_t ints = save_and_disable_interrupts();
+    flash_range_erase(FLASH_CONFIG_OFFSET, FLASH_SECTOR_SIZE);
+    flash_range_program(FLASH_CONFIG_OFFSET, page, FLASH_PAGE_SIZE);
+    restore_interrupts(ints);
+    printf("Config saved to flash\n");
+}
 
 // ============================================================================
 // USB HID CONFIGURATION - GENERIC HID MODE
 // ============================================================================
 
-// Vendor-defined HID Report Descriptor
-// Usage Page: 0xFF00 (Vendor Defined)
-// Report Size: 8 bytes (1 byte report ID + 7 bytes data)
+// Vendor-defined HID Report Descriptor with runtime config support
 static const uint8_t hid_report_descriptor[] = {
     0x06, 0x00, 0xFF,  // Usage Page (Vendor Defined 0xFF00)
     0x09, 0x01,        // Usage (Vendor Usage 1)
     0xA1, 0x01,        // Collection (Application)
+
+    // ---- Input Report ID 0x01: Encoder Positions (21 bytes) ----
     0x85, 0x01,        //   Report ID (1)
-    
-    // Encoder values (4 signed bytes for relative movement)
-    0x09, 0x02,        //   Usage (Vendor Usage 2 - Encoder Data)
-    0x15, 0x81,        //   Logical Minimum (-127)
-    0x25, 0x7F,        //   Logical Maximum (127)
+
+    // 4 encoder positions as 32-bit values (16 bytes)
+    0x09, 0x02,        //   Usage (Vendor Usage 2 - Encoder Positions)
+    0x16, 0x00, 0x80,  //   Logical Minimum (-32768)
+    0x26, 0xFF, 0x7F,  //   Logical Maximum (32767)
     0x75, 0x08,        //   Report Size (8 bits)
-    0x95, 0x04,        //   Report Count (4 encoders)
-    0x81, 0x06,        //   Input (Data, Variable, Relative)
-    
-    // Button states (1 byte with 4 button bits + 4 padding bits)
+    0x95, 0x10,        //   Report Count (16 bytes = 4x int32)
+    0x81, 0x02,        //   Input (Data, Variable, Absolute)
+
+    // Button states (1 byte: bits 0-3 = buttons, bits 4-7 = padding)
     0x09, 0x03,        //   Usage (Vendor Usage 3 - Button Data)
     0x15, 0x00,        //   Logical Minimum (0)
     0x25, 0x01,        //   Logical Maximum (1)
@@ -63,16 +276,42 @@ static const uint8_t hid_report_descriptor[] = {
     0x81, 0x02,        //   Input (Data, Variable, Absolute)
     0x75, 0x01,        //   Report Size (1 bit)
     0x95, 0x04,        //   Report Count (4 padding bits)
-    0x81, 0x03,        //   Input (Constant, Variable, Absolute) - Padding
-    
-    // Reserved bytes (2 bytes for future use)
-    0x09, 0x04,        //   Usage (Vendor Usage 4 - Reserved)
+    0x81, 0x03,        //   Input (Constant, Variable, Absolute)
+
+    // Acceleration tier byte + 3 reserved bytes (4 bytes)
+    0x09, 0x04,        //   Usage (Vendor Usage 4 - Tier + Reserved)
     0x15, 0x00,        //   Logical Minimum (0)
     0x26, 0xFF, 0x00,  //   Logical Maximum (255)
     0x75, 0x08,        //   Report Size (8 bits)
-    0x95, 0x02,        //   Report Count (2 reserved bytes)
+    0x95, 0x04,        //   Report Count (4: tier byte + 3 reserved)
     0x81, 0x02,        //   Input (Data, Variable, Absolute)
-    
+
+    // ---- Input Report ID 0x02: Config Readback (106 bytes) ----
+    0x85, 0x02,        //   Report ID (2)
+    0x09, 0x05,        //   Usage (Vendor Usage 5 - Config Readback)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8 bits)
+    0x95, 0x6A,        //   Report Count (106 bytes)
+    0x81, 0x02,        //   Input (Data, Variable, Absolute)
+
+    // ---- Output Report ID 0x02: Config Write (106 bytes) ----
+    0x09, 0x06,        //   Usage (Vendor Usage 6 - Config Write)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8 bits)
+    0x95, 0x6A,        //   Report Count (106 bytes)
+    0x91, 0x02,        //   Output (Data, Variable, Absolute)
+
+    // ---- Output Report ID 0x03: Commands (2 bytes) ----
+    0x85, 0x03,        //   Report ID (3)
+    0x09, 0x07,        //   Usage (Vendor Usage 7 - Commands)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8 bits)
+    0x95, 0x02,        //   Report Count (2 bytes)
+    0x91, 0x02,        //   Output (Data, Variable, Absolute)
+
     0xC0               // End Collection
 };
 
@@ -80,59 +319,38 @@ static const uint8_t hid_report_descriptor[] = {
 // ENCODER CONFIGURATION
 // ============================================================================
 
-// GPIO Pin mapping for 4 encoders
-// Encoder 1: A=GP2, B=GP3, SW=GP4
-// Encoder 2: A=GP5, B=GP6, SW=GP7
-// Encoder 3: A=GP8, B=GP9, SW=GP10
-// Encoder 4: A=GP11, B=GP12, SW=GP13
-
 struct EncoderPinConfig {
     uint8_t pin_a;
     uint8_t pin_b;
     uint8_t pin_sw;
 };
 
-static const EncoderPinConfig ENCODER_PIN_CONFIGS[4] = {
+static const EncoderPinConfig ENCODER_PIN_CONFIGS[NUM_ENCODERS] = {
     { 2,  3,  4  },  // Encoder 1
     { 5,  6,  7  },  // Encoder 2
     { 8,  9,  10 },  // Encoder 3
     { 11, 12, 13 },  // Encoder 4
 };
 
-// Number of encoders
-constexpr size_t NUM_ENCODERS = 4;
-
-// Number of quadrature state changes per physical detent.
-// KY-040 modules (full-cycle): 4
-// Many bare EC11 encoders (half-cycle): 2
-static constexpr int8_t STEPS_PER_DETENT = 4;
-
-// Set true to swap CW/CCW direction for all encoders.
-// Useful if your encoder's A/B pins are wired in reverse.
-static constexpr bool REVERSE_DIRECTION = false;
-
 // ============================================================================
-// GENERIC HID ENCODER CLASS
+// GENERIC HID ENCODER CLASS (with absolute position tracking)
 // ============================================================================
 
-/**
- * @brief Encoder class modified for Generic HID mode
- * Accumulates movement instead of sending individual key events
- */
 class GenericHidEncoder {
 public:
     GenericHidEncoder(uint8_t pin_a, uint8_t pin_b, uint8_t pin_sw,
-                      uint8_t encoder_id, int8_t steps_per_detent = 4,
-                      bool reverse_direction = false)
+                      uint8_t encoder_id)
         : pin_a_(pin_a)
         , pin_b_(pin_b)
         , pin_sw_(pin_sw)
         , encoder_id_(encoder_id)
         , last_ab_state_(0)
         , steps_(0)
-        , steps_per_detent_(steps_per_detent)
-        , reverse_direction_(reverse_direction)
-        , accumulated_movement_(0)
+        , position_(0)
+        , last_detent_time_us_(0)
+        , active_tier_(0)
+        , config_(nullptr)
+        , steps_per_detent_(4)
         , last_button_state_(true)
         , button_pressed_(false)
         , debounce_start_(0)
@@ -140,34 +358,46 @@ public:
     {}
 
     void init() {
-        // Initialize pin A with pull-up
         gpio_init(pin_a_);
         gpio_set_dir(pin_a_, GPIO_IN);
         gpio_pull_up(pin_a_);
 
-        // Initialize pin B with pull-up
         gpio_init(pin_b_);
         gpio_set_dir(pin_b_, GPIO_IN);
         gpio_pull_up(pin_b_);
 
-        // Initialize button pin with pull-up
         gpio_init(pin_sw_);
         gpio_set_dir(pin_sw_, GPIO_IN);
         gpio_pull_up(pin_sw_);
 
-        // Read initial state
         last_ab_state_ = read_ab_state();
         last_button_state_ = gpio_get(pin_sw_);
+        last_detent_time_us_ = time_us_32();
 
         printf("Encoder %d initialized: A=GP%d, B=GP%d, SW=GP%d\n",
                encoder_id_, pin_a_, pin_b_, pin_sw_);
     }
 
-    /**
-     * @brief Update encoder state
-     * @return Current button pressed state
-     */
+    void apply_config(EncoderConfig* config, int8_t steps_per_detent) {
+        config_ = config;
+        steps_per_detent_ = steps_per_detent;
+    }
+
+    void reset_position() {
+        if (config_) {
+            position_ = config_->min_value;
+        } else {
+            position_ = 0;
+        }
+        active_tier_ = 0;
+    }
+
+    int32_t get_position() const { return position_; }
+    uint8_t get_active_tier() const { return active_tier_; }
+
     bool update() {
+        if (!config_) return button_pressed_;
+
         // Process encoder rotation
         uint8_t current_ab_state = read_ab_state();
 
@@ -176,20 +406,37 @@ public:
             int8_t direction = TRANSITION_TABLE[index];
 
             if (direction != 0) {
-                if (reverse_direction_) direction = -direction;
+                if (config_->reverse) direction = -direction;
                 steps_ += direction;
 
-                if (steps_ >= steps_per_detent_) {
-                    accumulated_movement_++;
+                if (steps_ >= steps_per_detent_ || steps_ <= -steps_per_detent_) {
+                    int8_t detent_direction = (steps_ > 0) ? 1 : -1;
                     steps_ = 0;
-                    printf("Encoder %d: CW detent\n", encoder_id_);
-                } else if (steps_ <= -steps_per_detent_) {
-                    accumulated_movement_--;
-                    steps_ = 0;
-                    printf("Encoder %d: CCW detent\n", encoder_id_);
+
+                    // Compute acceleration
+                    uint32_t now = time_us_32();
+                    uint32_t interval_us = now - last_detent_time_us_;
+                    uint32_t interval_ms = interval_us / 1000;
+                    last_detent_time_us_ = now;
+
+                    TierResult tier = select_acceleration_tier(interval_ms, config_->tiers);
+                    active_tier_ = tier.tier_index;
+
+                    int32_t effective_step = compute_effective_step(config_->step_size, tier.multiplier);
+
+                    // Update position
+                    int64_t new_pos = (int64_t)position_ + (int64_t)detent_direction * (int64_t)effective_step;
+                    if (new_pos > INT32_MAX) new_pos = INT32_MAX;
+                    if (new_pos < INT32_MIN) new_pos = INT32_MIN;
+
+                    position_ = clamp_position((int32_t)new_pos, config_->min_value,
+                                               config_->max_value, config_->wrap != 0);
+
+                    printf("Enc%d: %s pos=%ld tier=%d\n", encoder_id_,
+                           detent_direction > 0 ? "CW" : "CCW",
+                           (long)position_, active_tier_);
                 }
             } else {
-                // Invalid transition (noise) — reset step accumulator
                 steps_ = 0;
             }
 
@@ -210,10 +457,8 @@ public:
 
                 if (!current_button_state && !button_pressed_) {
                     button_pressed_ = true;
-                    printf("Encoder %d: Button pressed\n", encoder_id_);
                 } else if (current_button_state && button_pressed_) {
                     button_pressed_ = false;
-                    printf("Encoder %d: Button released\n", encoder_id_);
                 }
             }
         } else {
@@ -223,18 +468,6 @@ public:
         return button_pressed_;
     }
 
-    /**
-     * @brief Get accumulated movement and reset counter
-     * @return Signed movement value clamped to -127 to +127
-     */
-    int8_t get_and_clear_movement() {
-        int8_t movement = accumulated_movement_;
-        if (movement > 127) movement = 127;
-        if (movement < -127) movement = -127;
-        accumulated_movement_ = 0;
-        return movement;
-    }
-
 private:
     uint8_t read_ab_state() {
         uint8_t a_val = gpio_get(pin_a_) ? 0 : 1;
@@ -242,75 +475,52 @@ private:
         return (a_val << 1) | b_val;
     }
 
-    // Pin assignments
     uint8_t pin_a_;
     uint8_t pin_b_;
     uint8_t pin_sw_;
     uint8_t encoder_id_;
 
-    // Encoder state
     uint8_t last_ab_state_;
     int8_t steps_;
-    int8_t steps_per_detent_;
-    bool reverse_direction_;
-    int16_t accumulated_movement_;
 
-    // Button state (first-edge-latch debounce)
+    // Absolute position tracking
+    int32_t position_;
+    uint32_t last_detent_time_us_;
+    uint8_t active_tier_;
+
+    // Config pointer (points into device_config.encoders[])
+    EncoderConfig* config_;
+    int8_t steps_per_detent_;
+
+    // Button state
     bool last_button_state_;
     bool button_pressed_;
     uint32_t debounce_start_;
     bool debounce_active_;
 
-    // Constants
     static constexpr uint32_t BUTTON_DEBOUNCE_US = 20000;  // 20ms
-
-    // Quadrature state transition table
     static const int8_t TRANSITION_TABLE[16];
 };
 
-// Static transition table initialization
 const int8_t GenericHidEncoder::TRANSITION_TABLE[16] = {
-    0,  // 00 -> 00: no change
-    +1, // 00 -> 01: CW
-    -1, // 00 -> 10: CCW
-    0,  // 00 -> 11: invalid
-    -1, // 01 -> 00: CCW
-    0,  // 01 -> 01: no change
-    0,  // 01 -> 10: invalid
-    +1, // 01 -> 11: CW
-    +1, // 10 -> 00: CW
-    0,  // 10 -> 01: invalid
-    0,  // 10 -> 10: no change
-    -1, // 10 -> 11: CCW
-    0,  // 11 -> 00: invalid
-    -1, // 11 -> 01: CCW
-    +1, // 11 -> 10: CW
-    0   // 11 -> 11: no change
+     0, +1, -1,  0,
+    -1,  0,  0, +1,
+    +1,  0,  0, -1,
+     0, -1, +1,  0
 };
 
 // Encoder instances
 static GenericHidEncoder* encoders[NUM_ENCODERS];
 
-// ============================================================================
-// GENERIC HID REPORT
-// ============================================================================
-
-// Report structure (matches HID descriptor)
-struct GenericHidReport {
-    int8_t encoder_movement[4];  // Signed movement for each encoder
-    uint8_t button_states;       // Bit 0-3: buttons 1-4
-    uint8_t reserved[2];         // Reserved for future use
-};
-
-static GenericHidReport current_report;
-static GenericHidReport last_report;
-static bool report_pending = false;
+// Report state
+static PositionReport current_report;
+static PositionReport last_report;
+static bool pending_config_readback = false;
 
 // ============================================================================
-// TINYUSB CALLBACKS
+// TINYUSB DESCRIPTORS AND CALLBACKS
 // ============================================================================
 
-// Device descriptor
 static const tusb_desc_device_t device_descriptor = {
     .bLength            = sizeof(tusb_desc_device_t),
     .bDescriptorType    = TUSB_DESC_DEVICE,
@@ -319,14 +529,8 @@ static const tusb_desc_device_t device_descriptor = {
     .bDeviceSubClass    = 0x00,
     .bDeviceProtocol    = 0x00,
     .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
-    // WARNING: Placeholder VID/PID for development only!
-    // 0xCAFE is not an officially assigned Vendor ID and may conflict with other devices.
-    // For production use, either:
-    // 1. Obtain an official VID from USB-IF (https://www.usb.org/getting-vendor-id)
-    // 2. Use Raspberry Pi Foundation's VID with a sub-licensed PID
-    // 3. Use pid.codes for open source projects (https://pid.codes/)
     .idVendor           = 0xCAFE,
-    .idProduct          = 0x4005,  // Different PID for Generic HID version
+    .idProduct          = 0x4005,
     .bcdDevice          = 0x0100,
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,
@@ -334,23 +538,25 @@ static const tusb_desc_device_t device_descriptor = {
     .bNumConfigurations = 0x01
 };
 
-// HID interface descriptor
 enum {
     ITF_NUM_HID,
     ITF_NUM_TOTAL
 };
 
-#define CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN)
-#define EPNUM_HID   0x81
+// Use INOUT descriptor for bidirectional HID (Output Reports via interrupt EP)
+#define CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_HID_INOUT_DESC_LEN)
+#define EPNUM_HID_IN   0x81
+#define EPNUM_HID_OUT  0x01
 
 static const uint8_t configuration_descriptor[] = {
-    // Configuration descriptor
-    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
-    // HID descriptor - use HID_ITF_PROTOCOL_NONE for vendor-defined
-    TUD_HID_DESCRIPTOR(ITF_NUM_HID, 0, HID_ITF_PROTOCOL_NONE, sizeof(hid_report_descriptor), EPNUM_HID, CFG_TUD_HID_EP_BUFSIZE, 10)
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN,
+                          TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 0, HID_ITF_PROTOCOL_NONE,
+                             sizeof(hid_report_descriptor),
+                             EPNUM_HID_OUT, EPNUM_HID_IN,
+                             CFG_TUD_HID_EP_BUFSIZE, 10)
 };
 
-// String descriptors
 static const char* string_descriptors[] = {
     (const char[]) { 0x09, 0x04 },  // 0: Language (English)
     "RotaryUsb",                     // 1: Manufacturer
@@ -358,24 +564,20 @@ static const char* string_descriptors[] = {
     "123456",                        // 3: Serial
 };
 
-// Invoked when received GET DEVICE DESCRIPTOR
 const uint8_t* tud_descriptor_device_cb(void) {
     return (const uint8_t*)&device_descriptor;
 }
 
-// Invoked when received GET CONFIGURATION DESCRIPTOR
 const uint8_t* tud_descriptor_configuration_cb(uint8_t index) {
     (void)index;
     return configuration_descriptor;
 }
 
-// Invoked when received GET HID REPORT DESCRIPTOR
 const uint8_t* tud_hid_descriptor_report_cb(uint8_t instance) {
     (void)instance;
     return hid_report_descriptor;
 }
 
-// Invoked when received GET STRING DESCRIPTOR
 const uint16_t* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     (void)langid;
     static uint16_t str_desc[32];
@@ -388,11 +590,9 @@ const uint16_t* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
         if (index >= sizeof(string_descriptors) / sizeof(string_descriptors[0])) {
             return NULL;
         }
-
         const char* str = string_descriptors[index];
         chr_count = strlen(str);
         if (chr_count > 31) chr_count = 31;
-
         for (uint8_t i = 0; i < chr_count; i++) {
             str_desc[1 + i] = str[i];
         }
@@ -402,18 +602,51 @@ const uint16_t* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     return str_desc;
 }
 
-// Invoked when received SET_REPORT control request
+// Handle Output Reports from host
 void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id,
                            hid_report_type_t report_type, uint8_t const* buffer,
                            uint16_t bufsize) {
     (void)instance;
-    (void)report_id;
     (void)report_type;
-    (void)buffer;
-    (void)bufsize;
+
+    if (report_id == 0x02 && bufsize >= FULL_CONFIG_SIZE) {
+        // Config write
+        DeviceConfig new_config;
+        memcpy(&new_config, buffer, sizeof(DeviceConfig));
+        if (validate_config(new_config)) {
+            memcpy(&device_config, &new_config, sizeof(DeviceConfig));
+            int8_t spd = (device_config.global_flags & 0x01) ? 2 : 4;
+            for (size_t i = 0; i < NUM_ENCODERS; i++) {
+                encoders[i]->apply_config(&device_config.encoders[i], spd);
+            }
+            printf("Config applied from host\n");
+        } else {
+            printf("Config rejected: validation failed\n");
+        }
+    } else if (report_id == 0x03 && bufsize >= 2) {
+        // Command
+        uint8_t command = buffer[0];
+        if (command == CMD_SAVE_CONFIG) {
+            save_config_to_flash();
+        } else if (command == CMD_RESET_DEFAULTS) {
+            device_config = factory_default_config();
+            int8_t spd = (device_config.global_flags & 0x01) ? 2 : 4;
+            for (size_t i = 0; i < NUM_ENCODERS; i++) {
+                encoders[i]->apply_config(&device_config.encoders[i], spd);
+                encoders[i]->reset_position();
+            }
+            printf("Reset to factory defaults\n");
+        } else if (command == CMD_RESET_POSITIONS) {
+            for (size_t i = 0; i < NUM_ENCODERS; i++) {
+                encoders[i]->reset_position();
+            }
+            printf("All positions reset\n");
+        } else if (command == CMD_READ_CONFIG) {
+            pending_config_readback = true;
+        }
+    }
 }
 
-// Invoked when received GET_REPORT control request
 uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id,
                                 hid_report_type_t report_type, uint8_t* buffer,
                                 uint16_t reqlen) {
@@ -426,17 +659,11 @@ uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id,
 }
 
 // ============================================================================
-// HID TASK
+// HID TASKS
 // ============================================================================
 
-// Cache button states from fast encoder polling for use by rate-limited HID reports
 static uint8_t cached_button_states = 0;
 
-/**
- * @brief Poll all encoders at full speed (called from main loop).
- * Encoder rotation and button state are tracked internally;
- * hid_task() collects accumulated movement at report intervals.
- */
 static void encoder_poll_task() {
     uint8_t button_states = 0;
     for (size_t i = 0; i < NUM_ENCODERS; i++) {
@@ -447,10 +674,6 @@ static void encoder_poll_task() {
     cached_button_states = button_states;
 }
 
-/**
- * @brief Send HID reports at a rate-limited interval.
- * Encoder polling happens separately in encoder_poll_task().
- */
 static void hid_task() {
     const uint32_t interval_ms = 10;
     static uint32_t start_ms = 0;
@@ -460,38 +683,28 @@ static void hid_task() {
 
     if (!tud_hid_ready()) return;
 
-    // Collect accumulated movement from encoders
+    // Send config readback if requested
+    if (pending_config_readback) {
+        tud_hid_report(2, &device_config, sizeof(DeviceConfig));
+        pending_config_readback = false;
+        printf("Config readback sent\n");
+        return;  // One report per interval
+    }
+
+    // Build position report
+    uint8_t tier_byte = 0;
     for (size_t i = 0; i < NUM_ENCODERS; i++) {
-        current_report.encoder_movement[i] = encoders[i]->get_and_clear_movement();
+        current_report.positions[i] = encoders[i]->get_position();
+        tier_byte |= (encoders[i]->get_active_tier() & 0x03) << (i * 2);
     }
     current_report.button_states = cached_button_states;
-    current_report.reserved[0] = 0;
-    current_report.reserved[1] = 0;
+    current_report.active_tiers = tier_byte;
+    memset(current_report.reserved, 0, sizeof(current_report.reserved));
 
-    // Check if report has changed or has movement data
-    bool has_movement = false;
-    for (size_t i = 0; i < NUM_ENCODERS; i++) {
-        if (current_report.encoder_movement[i] != 0) {
-            has_movement = true;
-            break;
-        }
-    }
-
-    bool has_change = memcmp(&current_report, &last_report, sizeof(GenericHidReport)) != 0;
-
-    if (has_movement || has_change) {
-        tud_hid_report(1, &current_report, sizeof(GenericHidReport));
-
-        if (has_movement) {
-            printf("Report: Enc[%d,%d,%d,%d] Btn=0x%02X\n",
-                   current_report.encoder_movement[0],
-                   current_report.encoder_movement[1],
-                   current_report.encoder_movement[2],
-                   current_report.encoder_movement[3],
-                   current_report.button_states);
-        }
-
-        memcpy(&last_report, &current_report, sizeof(GenericHidReport));
+    // Only send if something changed
+    if (memcmp(&current_report, &last_report, sizeof(PositionReport)) != 0) {
+        tud_hid_report(1, &current_report, sizeof(PositionReport));
+        memcpy(&last_report, &current_report, sizeof(PositionReport));
     }
 }
 
@@ -500,45 +713,41 @@ static void hid_task() {
 // ============================================================================
 
 int main() {
-    // Initialize stdio for debug output via UART
     stdio_init_all();
 
     printf("\n");
     printf("========================================\n");
-    printf("RotaryUsb Generic HID Firmware Starting...\n");
+    printf("RotaryUsb Generic HID (runtime config)\n");
     printf("========================================\n");
+
+    // Load config from flash
+    load_config_from_flash();
+    int8_t steps_per_detent = (device_config.global_flags & 0x01) ? 2 : 4;
 
     // Initialize TinyUSB
     tusb_init();
     printf("USB Generic HID initialized\n");
-    printf("Usage Page: 0xFF00, Usage: 0x01\n");
 
     // Create and initialize encoders
     for (size_t i = 0; i < NUM_ENCODERS; i++) {
-        const auto& cfg = ENCODER_PIN_CONFIGS[i];
+        const auto& pin_cfg = ENCODER_PIN_CONFIGS[i];
         encoders[i] = new GenericHidEncoder(
-            cfg.pin_a, cfg.pin_b, cfg.pin_sw,
-            i + 1, STEPS_PER_DETENT, REVERSE_DIRECTION
+            pin_cfg.pin_a, pin_cfg.pin_b, pin_cfg.pin_sw, i + 1
         );
         encoders[i]->init();
+        encoders[i]->apply_config(&device_config.encoders[i], steps_per_detent);
+        encoders[i]->reset_position();
     }
 
-    // Initialize report structures
-    memset(&current_report, 0, sizeof(GenericHidReport));
-    memset(&last_report, 0, sizeof(GenericHidReport));
+    memset(&current_report, 0, sizeof(PositionReport));
+    memset(&last_report, 0, sizeof(PositionReport));
 
     printf("All encoders initialized. Starting main loop...\n");
     printf("----------------------------------------\n");
 
-    // Main loop
     while (true) {
-        // Process USB tasks
         tud_task();
-
-        // Poll encoders at full speed (not rate-limited)
         encoder_poll_task();
-
-        // Send HID reports at rate-limited intervals
         hid_task();
     }
 

--- a/firmware-cpp/tusb_config.h
+++ b/firmware-cpp/tusb_config.h
@@ -61,7 +61,7 @@ extern "C" {
 #define CFG_TUD_VENDOR          0
 
 // HID buffer size
-#define CFG_TUD_HID_EP_BUFSIZE    16
+#define CFG_TUD_HID_EP_BUFSIZE    128
 
 #ifdef __cplusplus
 }

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -156,18 +156,17 @@ Modify `BUTTON_DEBOUNCE_TIME` (default: 20ms) if buttons are too sensitive or un
 
 ### HID Report Format
 
-When using Generic HID mode, the device sends 8-byte reports:
+When using Generic HID mode, the device sends 21-byte position reports (Input Report ID 0x01):
 
-| Byte | Description | Range |
-|------|-------------|-------|
-| 0 | Report ID | Always 0x01 |
-| 1 | Encoder 1 movement | -127 to +127 (signed, positive = CW) |
-| 2 | Encoder 2 movement | -127 to +127 (signed, positive = CW) |
-| 3 | Encoder 3 movement | -127 to +127 (signed, positive = CW) |
-| 4 | Encoder 4 movement | -127 to +127 (signed, positive = CW) |
-| 5 | Button states | Bit 0-3: Buttons 1-4 (1 = pressed) |
-| 6 | Reserved | 0x00 |
-| 7 | Reserved | 0x00 |
+| Offset | Type | Description |
+|--------|------|-------------|
+| 0-3 | int32 LE | Encoder 1 absolute position |
+| 4-7 | int32 LE | Encoder 2 absolute position |
+| 8-11 | int32 LE | Encoder 3 absolute position |
+| 12-15 | int32 LE | Encoder 4 absolute position |
+| 16 | uint8 | Button states (bit 0-3 = buttons 1-4) |
+| 17 | uint8 | Active acceleration tiers (packed 2-bit per encoder) |
+| 18-20 | uint8[3] | Reserved (0x00) |
 
 ### USB Identifiers
 
@@ -185,6 +184,42 @@ To read the Generic HID reports from your application:
 3. **Cross-platform:** Use hidapi bindings for your language
 
 See the `windows-example/` directory for a C# example using HidLibrary.
+
+### Runtime Configuration
+
+Generic HID mode now supports runtime configuration from the host application. Encoders track absolute positions (int32) instead of relative movement, with configurable bounds, step size, acceleration, and wrapping.
+
+#### New HID Report Protocol
+
+| Report | Direction | Size | Description |
+|--------|-----------|------|-------------|
+| Input ID 0x01 | Device → Host | 21 bytes | 4× int32 positions + buttons + acceleration tiers |
+| Input ID 0x02 | Device → Host | 106 bytes | Config readback (sent on command) |
+| Output ID 0x02 | Host → Device | 106 bytes | Full config write |
+| Output ID 0x03 | Host → Device | 2 bytes | Commands (save/reset/readback) |
+
+#### Per-Encoder Configuration
+
+Each encoder can be independently configured:
+- **min_value / max_value** (int32): Position bounds
+- **step_size** (int32): Base value change per detent
+- **wrap**: Wrap around at bounds vs clamp
+- **reverse**: Swap CW/CCW direction
+- **3 acceleration tiers**: Faster rotation applies larger step multipliers
+
+#### Flash Persistence
+
+Config is saved to `config.bin` on the CIRCUITPY filesystem. On boot, the device loads saved config or falls back to factory defaults (0-100 range, step=1).
+
+**Note:** `boot.py` calls `storage.remount("/", readonly=False)` which makes the CIRCUITPY drive read-only from the host PC. To edit files on the drive again, enter the REPL and run `storage.remount("/", readonly=True)`.
+
+#### Files
+
+| File | Purpose |
+|------|---------|
+| `boot.py` | HID descriptor with Input/Output Reports, storage setup |
+| `code_generic_hid.py` | Main firmware with position tracking and config handling |
+| `config.py` | Config data structures, validation, serialization (no CircuitPython deps) |
 
 ## Troubleshooting
 

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -1,52 +1,58 @@
 # SPDX-FileCopyrightText: 2024 RotaryUsb Project
 # SPDX-License-Identifier: Apache-2.0
 """
-CircuitPython boot.py for Generic HID Mode
+CircuitPython boot.py for Generic HID Mode — Runtime Configuration
 
 This boot.py configures the Raspberry Pi Pico to expose a vendor-defined
-Generic HID device instead of a standard keyboard. This allows applications
-to read raw encoder/button data directly via HID reports.
+Generic HID device with runtime configuration support. The device uses:
+
+  Input Report ID 0x01 (21 bytes): Absolute encoder positions + buttons + tiers
+  Input Report ID 0x02 (106 bytes): Config readback
+  Output Report ID 0x02 (106 bytes): Config write
+  Output Report ID 0x03 (2 bytes): Device commands
 
 INSTALLATION:
 1. Copy this file to the CIRCUITPY drive as boot.py
 2. Copy code_generic_hid.py to the CIRCUITPY drive as code.py
 3. Power cycle the device
 
-To switch back to Keyboard mode:
-- Delete boot.py from the CIRCUITPY drive
-- Copy code.py (the original keyboard version) to the drive
+NOTE: storage.remount() makes CIRCUITPY read-only from the PC so the
+firmware can write config.bin to flash. To edit files on the drive again,
+hold a button during boot or enter the REPL and run storage.remount("/", readonly=True).
 """
 
 import usb_hid
+import storage
+
+# Allow firmware to write to the filesystem (for config.bin persistence)
+storage.remount("/", readonly=False)
 
 # Vendor-defined HID report descriptor for RotaryUsb Generic HID device
 # Usage Page: 0xFF00 (Vendor Defined)
 # Usage: 0x01 (Vendor Usage 1)
-# Report Size: 8 bytes
-#   Byte 0: Report ID (0x01)
-#   Byte 1: Encoder 1 movement (signed 8-bit, relative)
-#   Byte 2: Encoder 2 movement (signed 8-bit, relative)
-#   Byte 3: Encoder 3 movement (signed 8-bit, relative)
-#   Byte 4: Encoder 4 movement (signed 8-bit, relative)
-#   Byte 5: Button states (bit 0-3 for buttons 1-4, 1=pressed)
-#   Byte 6: Reserved
-#   Byte 7: Reserved
+#
+# Input Report ID 0x01 — 21 bytes: encoder positions + buttons + tiers
+# Input Report ID 0x02 — 106 bytes: config readback
+# Output Report ID 0x02 — 106 bytes: config write
+# Output Report ID 0x03 — 2 bytes: device commands
 
 GENERIC_HID_REPORT_DESCRIPTOR = bytes([
     0x06, 0x00, 0xFF,  # Usage Page (Vendor Defined 0xFF00)
     0x09, 0x01,        # Usage (Vendor Usage 1)
     0xA1, 0x01,        # Collection (Application)
+
+    # ---- Input Report ID 0x01: Encoder Positions (21 bytes) ----
     0x85, 0x01,        #   Report ID (1)
-    
-    # Encoder values (4 signed bytes for relative movement)
-    0x09, 0x02,        #   Usage (Vendor Usage 2 - Encoder Data)
-    0x15, 0x81,        #   Logical Minimum (-127)
-    0x25, 0x7F,        #   Logical Maximum (127)
+
+    # 4 encoder positions as 32-bit signed values (16 bytes)
+    0x09, 0x02,        #   Usage (Vendor Usage 2 - Encoder Positions)
+    0x16, 0x00, 0x80,  #   Logical Minimum (-32768) — placeholder for vendor data
+    0x26, 0xFF, 0x7F,  #   Logical Maximum (32767) — placeholder for vendor data
     0x75, 0x08,        #   Report Size (8 bits)
-    0x95, 0x04,        #   Report Count (4 encoders)
-    0x81, 0x06,        #   Input (Data, Variable, Relative)
-    
-    # Button states (1 byte with 4 button bits + 4 padding bits)
+    0x95, 0x10,        #   Report Count (16 bytes = 4x int32)
+    0x81, 0x02,        #   Input (Data, Variable, Absolute)
+
+    # Button states (1 byte: bits 0-3 = buttons 1-4, bits 4-7 = padding)
     0x09, 0x03,        #   Usage (Vendor Usage 3 - Button Data)
     0x15, 0x00,        #   Logical Minimum (0)
     0x25, 0x01,        #   Logical Maximum (1)
@@ -56,30 +62,62 @@ GENERIC_HID_REPORT_DESCRIPTOR = bytes([
     0x75, 0x01,        #   Report Size (1 bit)
     0x95, 0x04,        #   Report Count (4 padding bits)
     0x81, 0x03,        #   Input (Constant, Variable, Absolute) - Padding
-    
-    # Reserved bytes (2 bytes for future use)
-    0x09, 0x04,        #   Usage (Vendor Usage 4 - Reserved)
+
+    # Acceleration tier byte + 3 reserved bytes (4 bytes)
+    0x09, 0x04,        #   Usage (Vendor Usage 4 - Tier + Reserved)
     0x15, 0x00,        #   Logical Minimum (0)
     0x26, 0xFF, 0x00,  #   Logical Maximum (255)
     0x75, 0x08,        #   Report Size (8 bits)
-    0x95, 0x02,        #   Report Count (2 reserved bytes)
+    0x95, 0x04,        #   Report Count (4: tier byte + 3 reserved)
     0x81, 0x02,        #   Input (Data, Variable, Absolute)
-    
+
+    # ---- Input Report ID 0x02: Config Readback (106 bytes) ----
+    0x85, 0x02,        #   Report ID (2)
+    0x09, 0x05,        #   Usage (Vendor Usage 5 - Config Readback)
+    0x15, 0x00,        #   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  #   Logical Maximum (255)
+    0x75, 0x08,        #   Report Size (8 bits)
+    0x95, 0x6A,        #   Report Count (106 bytes)
+    0x81, 0x02,        #   Input (Data, Variable, Absolute)
+
+    # ---- Output Report ID 0x02: Config Write (106 bytes) ----
+    0x09, 0x06,        #   Usage (Vendor Usage 6 - Config Write)
+    0x15, 0x00,        #   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  #   Logical Maximum (255)
+    0x75, 0x08,        #   Report Size (8 bits)
+    0x95, 0x6A,        #   Report Count (106 bytes)
+    0x91, 0x02,        #   Output (Data, Variable, Absolute)
+
+    # ---- Output Report ID 0x03: Commands (2 bytes) ----
+    0x85, 0x03,        #   Report ID (3)
+    0x09, 0x07,        #   Usage (Vendor Usage 7 - Commands)
+    0x15, 0x00,        #   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  #   Logical Maximum (255)
+    0x75, 0x08,        #   Report Size (8 bits)
+    0x95, 0x02,        #   Report Count (2 bytes)
+    0x91, 0x02,        #   Output (Data, Variable, Absolute)
+
     0xC0               # End Collection
 ])
 
 # Create the Generic HID device descriptor
+# report_ids: all report IDs used across Input and Output reports
+# in_report_lengths: indexed by report ID — size of Input Report for each ID
+#   ID 1 = 21 bytes, ID 2 = 106 bytes, ID 3 = no input (0)
+# out_report_lengths: indexed by report ID — size of Output Report for each ID
+#   ID 1 = no output (0), ID 2 = 106 bytes, ID 3 = 2 bytes
 GENERIC_HID_DEVICE = usb_hid.Device(
     report_descriptor=GENERIC_HID_REPORT_DESCRIPTOR,
-    usage_page=0xFF00,       # Vendor Defined
-    usage=0x01,              # Vendor Usage 1
-    report_ids=(1,),         # Report ID 1
-    in_report_lengths=(7,),  # 7 bytes per report (excluding report ID)
-    out_report_lengths=(0,), # No output reports
+    usage_page=0xFF00,                    # Vendor Defined
+    usage=0x01,                           # Vendor Usage 1
+    report_ids=(1, 2, 3),                 # All report IDs
+    in_report_lengths=(21, 106, 0),       # Input Report sizes per ID
+    out_report_lengths=(0, 106, 2),       # Output Report sizes per ID
 )
 
 # Enable only the Generic HID device (disable default keyboard/mouse)
 usb_hid.enable((GENERIC_HID_DEVICE,))
 
-print("RotaryUsb Generic HID mode enabled")
-print("Report format: [ReportID][Enc1][Enc2][Enc3][Enc4][Buttons][Rsv1][Rsv2]")
+print("RotaryUsb Generic HID mode enabled (runtime config)")
+print("Input Reports: ID1=positions(21B), ID2=config_readback(106B)")
+print("Output Reports: ID2=config_write(106B), ID3=commands(2B)")

--- a/firmware/boot.py
+++ b/firmware/boot.py
@@ -44,10 +44,12 @@ GENERIC_HID_REPORT_DESCRIPTOR = bytes([
     # ---- Input Report ID 0x01: Encoder Positions (21 bytes) ----
     0x85, 0x01,        #   Report ID (1)
 
-    # 4 encoder positions as 32-bit signed values (16 bytes)
+    # 4 encoder positions as 32-bit signed values (16 raw bytes)
+    # Logical min/max are nominal; actual int32 values are parsed by the host app
+    # from the raw vendor-defined bytes, not by the HID driver.
     0x09, 0x02,        #   Usage (Vendor Usage 2 - Encoder Positions)
-    0x16, 0x00, 0x80,  #   Logical Minimum (-32768) — placeholder for vendor data
-    0x26, 0xFF, 0x7F,  #   Logical Maximum (32767) — placeholder for vendor data
+    0x15, 0x00,        #   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  #   Logical Maximum (255)
     0x75, 0x08,        #   Report Size (8 bits)
     0x95, 0x10,        #   Report Count (16 bytes = 4x int32)
     0x81, 0x02,        #   Input (Data, Variable, Absolute)

--- a/firmware/code_generic_hid.py
+++ b/firmware/code_generic_hid.py
@@ -2,33 +2,42 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 CircuitPython firmware for Raspberry Pi Pico - Generic HID Mode
+Runtime Configuration with Absolute Position Tracking
 
-Reads 4 rotary encoders with push buttons and sends raw USB HID reports
-to the host PC. This mode allows applications to read encoder data directly
-without keyboard event interception.
+Reads 4 rotary encoders with push buttons and sends absolute position data
+via USB HID reports. Supports runtime configuration from the host via
+Output Reports, with flash persistence.
 
 PREREQUISITES:
 - Copy boot.py (Generic HID version) to the CIRCUITPY drive first
 - Power cycle the device before copying this file
 
-Copy this file to the CIRCUITPY drive as code.py after installing CircuitPython
-and the adafruit_hid library.
+Copy this file to the CIRCUITPY drive as code.py after installing CircuitPython.
 
-HID REPORT FORMAT (8 bytes total):
-  Byte 0: Report ID (0x01 - handled by send_report)
-  Byte 1: Encoder 1 movement (signed: -127 to +127, positive=CW)
-  Byte 2: Encoder 2 movement (signed: -127 to +127, positive=CW)
-  Byte 3: Encoder 3 movement (signed: -127 to +127, positive=CW)
-  Byte 4: Encoder 4 movement (signed: -127 to +127, positive=CW)
-  Byte 5: Button states (bit 0=Btn1, bit 1=Btn2, bit 2=Btn3, bit 3=Btn4)
-  Byte 6: Reserved (0x00)
-  Byte 7: Reserved (0x00)
+HID REPORT FORMAT:
+  Input Report ID 0x01 (21 bytes):
+    Bytes 0-15: 4x int32 LE encoder positions
+    Byte 16: Button states (bits 0-3)
+    Byte 17: Active acceleration tiers (packed 2-bit fields)
+    Bytes 18-20: Reserved (0x00)
+
+  Input Report ID 0x02 (106 bytes): Config readback
+  Output Report ID 0x02 (106 bytes): Config write
+  Output Report ID 0x03 (2 bytes): Commands
 """
 
 import time
+import struct
 import board
 import digitalio
 import usb_hid
+
+from config import (
+    DeviceConfig, EncoderConfig,
+    factory_default_config, validate_config,
+    clamp_position, select_acceleration_tier, compute_effective_step,
+    FULL_CONFIG_SIZE,
+)
 
 # ============================================================================
 # CONFIGURATION
@@ -43,40 +52,68 @@ ENCODER_PINS = [
     {"a": board.GP11, "b": board.GP12, "sw": board.GP13}, # Encoder 4
 ]
 
-# Encoder tuning
-# Number of quadrature state changes per physical detent.
-# KY-040 modules (full-cycle): 4
-# Many bare EC11 encoders (half-cycle): 2
-STEPS_PER_DETENT = 4
-
-# Set True to swap CW/CCW direction for all encoders.
-# Useful if your encoder's A/B pins are wired in reverse.
-REVERSE_DIRECTION = False
-
 # Debounce timing (in seconds)
 BUTTON_DEBOUNCE_TIME = 0.020  # 20ms debounce for buttons
 LOOP_DELAY = 0.001  # 1ms loop delay
 REPORT_INTERVAL = 0.010  # 10ms minimum between reports
 
+# Config file path on CIRCUITPY filesystem
+CONFIG_FILE = "/config.bin"
+
 # Debug output to serial console
 DEBUG_ENABLED = True
 
+# Command codes (Output Report ID 0x03)
+CMD_SAVE_CONFIG = 0x01
+CMD_RESET_DEFAULTS = 0x02
+CMD_RESET_POSITIONS = 0x03
+CMD_READ_CONFIG = 0x04
+
 # ============================================================================
-# ENCODER CLASS (Generic HID version)
+# FLASH PERSISTENCE
+# ============================================================================
+
+def load_config_from_flash():
+    """Load config from flash. Returns DeviceConfig or None."""
+    try:
+        with open(CONFIG_FILE, "rb") as f:
+            data = f.read()
+        if len(data) != FULL_CONFIG_SIZE:
+            return None
+        config = DeviceConfig.unpack(data)
+        if config is not None and validate_config(config):
+            return config
+    except OSError:
+        pass
+    return None
+
+
+def save_config_to_flash(config):
+    """Save config to flash. Returns True on success."""
+    try:
+        data = config.pack()
+        with open(CONFIG_FILE, "wb") as f:
+            f.write(data)
+        return True
+    except OSError as e:
+        if DEBUG_ENABLED:
+            print(f"Error saving config: {e}")
+        return False
+
+
+# ============================================================================
+# ENCODER CLASS (Generic HID version with absolute position tracking)
 # ============================================================================
 
 class Encoder:
     """
     Handles a single rotary encoder with push button for Generic HID mode.
-    
-    Uses quadrature decoding to detect rotation direction and
-    software debouncing for the push button. Returns raw movement
-    values instead of sending keyboard events.
+
+    Uses quadrature decoding to detect rotation direction. Tracks absolute
+    position with configurable bounds, acceleration, and wrapping.
     """
-    
+
     # Quadrature state transition table
-    # Maps (previous_state, current_state) to direction
-    # +1 = clockwise, -1 = counter-clockwise, 0 = no valid transition
     TRANSITION_TABLE = {
         (0b00, 0b01): +1,
         (0b01, 0b11): +1,
@@ -87,61 +124,63 @@ class Encoder:
         (0b11, 0b01): -1,
         (0b01, 0b00): -1,
     }
-    
-    def __init__(self, pin_a, pin_b, pin_sw, encoder_id=0):
-        """
-        Initialize an encoder instance.
-        
-        Args:
-            pin_a: GPIO pin for encoder A (CLK)
-            pin_b: GPIO pin for encoder B (DT)
-            pin_sw: GPIO pin for encoder push button (SW)
-            encoder_id: Identifier for debug output
-        """
+
+    def __init__(self, pin_a, pin_b, pin_sw, encoder_id, config, steps_per_detent):
         self.encoder_id = encoder_id
-        
+        self.config = config
+        self.steps_per_detent = steps_per_detent
+
         # Initialize pin A
         self.pin_a = digitalio.DigitalInOut(pin_a)
         self.pin_a.direction = digitalio.Direction.INPUT
         self.pin_a.pull = digitalio.Pull.UP
-        
+
         # Initialize pin B
         self.pin_b = digitalio.DigitalInOut(pin_b)
         self.pin_b.direction = digitalio.Direction.INPUT
         self.pin_b.pull = digitalio.Pull.UP
-        
+
         # Initialize button pin
         self.pin_sw = digitalio.DigitalInOut(pin_sw)
         self.pin_sw.direction = digitalio.Direction.INPUT
         self.pin_sw.pull = digitalio.Pull.UP
-        
+
         # Encoder state tracking
         self.last_ab_state = self._read_ab_state()
         self.steps = 0
-        self.accumulated_movement = 0
+
+        # Absolute position tracking
+        self.position = config.min_value
+        self.last_detent_time = time.monotonic()
+        self.active_tier = 0
 
         # Button state tracking (first-edge-latch debounce)
-        self.last_button_state = self.pin_sw.value  # True = not pressed (pull-up)
+        self.last_button_state = self.pin_sw.value
         self.button_pressed = False
-        self.debounce_start = None  # Time of first edge, None when stable
-    
+        self.debounce_start = None
+
     def _read_ab_state(self):
         """Read current A/B state as 2-bit value."""
-        # Pins are active-low, so invert the reading
         a_val = 0 if self.pin_a.value else 1
         b_val = 0 if self.pin_b.value else 1
         return (a_val << 1) | b_val
-    
+
+    def apply_config(self, config, steps_per_detent):
+        """Apply new config without resetting position."""
+        self.config = config
+        self.steps_per_detent = steps_per_detent
+
+    def reset_position(self):
+        """Reset position to min_value."""
+        self.position = self.config.min_value
+        self.active_tier = 0
+
     def update(self):
         """
-        Update encoder state.
-        
-        Should be called frequently in the main loop.
-        Returns tuple: (movement, button_pressed)
-          - movement: Signed int (-127 to +127) for rotation since last report
-          - button_pressed: Boolean True if button is currently pressed
+        Update encoder state. Call frequently in the main loop.
+        Returns button_pressed boolean.
         """
-        # Process encoder rotation
+        cfg = self.config
         current_ab_state = self._read_ab_state()
 
         if current_ab_state != self.last_ab_state:
@@ -149,22 +188,35 @@ class Encoder:
             direction = self.TRANSITION_TABLE.get(transition, 0)
 
             if direction != 0:
-                if REVERSE_DIRECTION:
+                if cfg.reverse:
                     direction = -direction
                 self.steps += direction
 
-                if self.steps >= STEPS_PER_DETENT:
-                    self.accumulated_movement += 1
+                if self.steps >= self.steps_per_detent or self.steps <= -self.steps_per_detent:
+                    detent_direction = 1 if self.steps > 0 else -1
                     self.steps = 0
+
+                    # Compute acceleration
+                    now = time.monotonic()
+                    interval_ms = int((now - self.last_detent_time) * 1000)
+                    self.last_detent_time = now
+
+                    tier_idx, multiplier = select_acceleration_tier(
+                        interval_ms, cfg.tiers)
+                    self.active_tier = tier_idx
+
+                    effective_step = compute_effective_step(
+                        cfg.step_size, multiplier)
+
+                    # Update position
+                    self.position += detent_direction * effective_step
+                    self.position = clamp_position(
+                        self.position, cfg.min_value, cfg.max_value, cfg.wrap)
+
                     if DEBUG_ENABLED:
-                        print(f"Encoder {self.encoder_id}: CW detent")
-                elif self.steps <= -STEPS_PER_DETENT:
-                    self.accumulated_movement -= 1
-                    self.steps = 0
-                    if DEBUG_ENABLED:
-                        print(f"Encoder {self.encoder_id}: CCW detent")
+                        dir_str = "CW" if detent_direction > 0 else "CCW"
+                        print(f"Enc{self.encoder_id}: {dir_str} pos={self.position} tier={tier_idx}")
             else:
-                # Invalid transition (noise) — reset step accumulator
                 self.steps = 0
 
             self.last_ab_state = current_ab_state
@@ -182,27 +234,12 @@ class Encoder:
 
                 if not current_button_state and not self.button_pressed:
                     self.button_pressed = True
-                    if DEBUG_ENABLED:
-                        print(f"Encoder {self.encoder_id}: Button pressed")
                 elif current_button_state and self.button_pressed:
                     self.button_pressed = False
-                    if DEBUG_ENABLED:
-                        print(f"Encoder {self.encoder_id}: Button released")
         else:
             self.debounce_start = None
 
         return self.button_pressed
-    
-    def get_and_clear_movement(self):
-        """
-        Get accumulated movement since last call and reset counter.
-        
-        Returns:
-            Signed int clamped to -127 to +127 range
-        """
-        movement = max(-127, min(127, self.accumulated_movement))
-        self.accumulated_movement = 0
-        return movement
 
 
 # ============================================================================
@@ -210,34 +247,11 @@ class Encoder:
 # ============================================================================
 
 def find_generic_hid_device():
-    """
-    Find the Generic HID device configured by boot.py.
-    
-    Returns:
-        The usb_hid.Device instance or None if not found
-    """
+    """Find the Generic HID device configured by boot.py."""
     for device in usb_hid.devices:
-        # Look for our vendor-defined device (Usage Page 0xFF00)
         if device.usage_page == 0xFF00 and device.usage == 0x01:
             return device
     return None
-
-
-def signed_to_unsigned_byte(value):
-    """
-    Convert a signed integer to an unsigned byte using two's complement.
-    
-    Args:
-        value: Signed integer in range -127 to +127
-    
-    Returns:
-        Unsigned byte (0-255) representing the two's complement value.
-        This is needed because send_report expects unsigned bytes, but we
-        want to transmit signed movement values.
-    """
-    if value < 0:
-        return (256 + value) & 0xFF
-    return value & 0xFF
 
 
 # ============================================================================
@@ -246,21 +260,28 @@ def signed_to_unsigned_byte(value):
 
 def main():
     """Main entry point."""
-    print("RotaryUsb Generic HID Firmware Starting...")
-    print(f"Debug output: {'Enabled' if DEBUG_ENABLED else 'Disabled'}")
-    
+    print("RotaryUsb Generic HID Firmware Starting (runtime config)...")
+
     # Find the Generic HID device
     hid_device = find_generic_hid_device()
     if hid_device is None:
         print("ERROR: Generic HID device not found!")
         print("Make sure boot.py is installed and the device was power cycled.")
-        print("Available devices:")
-        for device in usb_hid.devices:
-            print(f"  - Usage Page: 0x{device.usage_page:04X}, Usage: 0x{device.usage:02X}")
         return
-    
+
     print(f"Generic HID device found: Usage Page 0x{hid_device.usage_page:04X}")
-    
+
+    # Load config from flash or use factory defaults
+    device_config = load_config_from_flash()
+    if device_config is not None:
+        print("Loaded config from flash")
+    else:
+        device_config = factory_default_config()
+        print("Using factory default config")
+
+    # Determine steps per detent from config
+    steps_per_detent = 2 if device_config.steps_per_detent_mode else 4
+
     # Create encoder instances
     encoders = []
     for i, pins in enumerate(ENCODER_PINS):
@@ -268,20 +289,20 @@ def main():
             pin_a=pins["a"],
             pin_b=pins["b"],
             pin_sw=pins["sw"],
-            encoder_id=i + 1
+            encoder_id=i + 1,
+            config=device_config.encoders[i],
+            steps_per_detent=steps_per_detent,
         )
         encoders.append(encoder)
-        print(f"Encoder {i + 1} initialized: A={pins['a']}, B={pins['b']}, SW={pins['sw']}")
-    
+        print(f"Encoder {i + 1} initialized: pos={encoder.position}")
+
     print("All encoders initialized. Starting main loop...")
-    print("-" * 40)
-    
-    # HID report buffer (7 bytes, report ID is handled separately)
-    # [Enc1][Enc2][Enc3][Enc4][Buttons][Reserved][Reserved]
-    report = bytearray(7)
+
+    # State
     last_report_time = time.monotonic()
-    last_report = bytearray(7)
-    
+    last_report = bytearray(21)
+    pending_config_readback = False
+
     # Main loop
     while True:
         # Update all encoders
@@ -290,38 +311,90 @@ def main():
             btn_pressed = encoder.update()
             if btn_pressed:
                 button_states |= (1 << i)
-        
+
+        # Check for Output Reports from host (poll each report ID separately)
+        # Report ID 0x02: Config write (106 bytes payload)
+        config_report = hid_device.get_last_received_report(2)
+        if config_report is not None:
+            if len(config_report) >= FULL_CONFIG_SIZE:
+                new_config = DeviceConfig.unpack(bytes(config_report[:FULL_CONFIG_SIZE]))
+                if new_config is not None and validate_config(new_config):
+                    device_config = new_config
+                    steps_per_detent = 2 if device_config.steps_per_detent_mode else 4
+                    for i, enc in enumerate(encoders):
+                        enc.apply_config(device_config.encoders[i], steps_per_detent)
+                    if DEBUG_ENABLED:
+                        print("Config applied from host")
+                else:
+                    if DEBUG_ENABLED:
+                        print("Config rejected: validation failed")
+
+        # Report ID 0x03: Commands (2 bytes payload)
+        cmd_report = hid_device.get_last_received_report(3)
+        if cmd_report is not None and len(cmd_report) >= 2:
+            command = cmd_report[0]
+            if command == CMD_SAVE_CONFIG:
+                ok = save_config_to_flash(device_config)
+                if DEBUG_ENABLED:
+                    print(f"Save config: {'OK' if ok else 'FAILED'}")
+            elif command == CMD_RESET_DEFAULTS:
+                device_config = factory_default_config()
+                steps_per_detent = 2 if device_config.steps_per_detent_mode else 4
+                for i, enc in enumerate(encoders):
+                    enc.apply_config(device_config.encoders[i], steps_per_detent)
+                    enc.reset_position()
+                if DEBUG_ENABLED:
+                    print("Reset to factory defaults")
+            elif command == CMD_RESET_POSITIONS:
+                for enc in encoders:
+                    enc.reset_position()
+                if DEBUG_ENABLED:
+                    print("All positions reset")
+            elif command == CMD_READ_CONFIG:
+                pending_config_readback = True
+
+        # Send config readback if requested
+        if pending_config_readback:
+            try:
+                config_data = device_config.pack()
+                hid_device.send_report(config_data, 2)  # Report ID 2
+                pending_config_readback = False
+                if DEBUG_ENABLED:
+                    print("Config readback sent")
+            except Exception as e:
+                if DEBUG_ENABLED:
+                    print(f"Config readback error: {e}")
+
         current_time = time.monotonic()
-        
-        # Send report at regular intervals or when state changes
+
+        # Send position report at regular intervals
         if (current_time - last_report_time) >= REPORT_INTERVAL:
-            # Build the HID report
-            for i, encoder in enumerate(encoders):
-                movement = encoder.get_and_clear_movement()
-                report[i] = signed_to_unsigned_byte(movement)
-            
-            report[4] = button_states  # Button states
-            report[5] = 0x00           # Reserved
-            report[6] = 0x00           # Reserved
-            
-            # Only send if something changed or there's movement
-            has_movement = any(report[i] != 0 for i in range(4))
-            has_change = report != last_report
-            
-            if has_movement or has_change:
+            # Build the 21-byte Input Report
+            # Pack tier info: 2 bits per encoder
+            tier_byte = 0
+            for i, enc in enumerate(encoders):
+                tier_byte |= (enc.active_tier & 0x03) << (i * 2)
+
+            report = struct.pack("<iiiiBBxxx",
+                                 encoders[0].position,
+                                 encoders[1].position,
+                                 encoders[2].position,
+                                 encoders[3].position,
+                                 button_states,
+                                 tier_byte)
+
+            # Only send if something changed
+            if report != last_report:
                 try:
-                    hid_device.send_report(report)
-                    if DEBUG_ENABLED and has_movement:
-                        print(f"Report: Enc[{report[0]:3d},{report[1]:3d},{report[2]:3d},{report[3]:3d}] Btn=0x{report[4]:02X}")
+                    hid_device.send_report(report, 1)  # Report ID 1
                 except Exception as e:
                     if DEBUG_ENABLED:
                         print(f"Error sending report: {e}")
-                
+
                 last_report = bytearray(report)
-            
+
             last_report_time = current_time
-        
-        # Small delay to prevent CPU hogging
+
         time.sleep(LOOP_DELAY)
 
 

--- a/firmware/code_generic_hid.py
+++ b/firmware/code_generic_hid.py
@@ -302,6 +302,7 @@ def main():
     last_report_time = time.monotonic()
     last_report = bytearray(21)
     pending_config_readback = False
+    readback_retry_time = 0  # Rate-limit readback retries
 
     # Main loop
     while True:
@@ -353,8 +354,9 @@ def main():
             elif command == CMD_READ_CONFIG:
                 pending_config_readback = True
 
-        # Send config readback if requested
-        if pending_config_readback:
+        # Send config readback if requested (rate-limited retries)
+        current_time = time.monotonic()
+        if pending_config_readback and current_time >= readback_retry_time:
             try:
                 config_data = device_config.pack()
                 hid_device.send_report(config_data, 2)  # Report ID 2
@@ -362,10 +364,9 @@ def main():
                 if DEBUG_ENABLED:
                     print("Config readback sent")
             except Exception as e:
+                readback_retry_time = current_time + 0.1  # Retry after 100ms
                 if DEBUG_ENABLED:
                     print(f"Config readback error: {e}")
-
-        current_time = time.monotonic()
 
         # Send position report at regular intervals
         if (current_time - last_report_time) >= REPORT_INTERVAL:

--- a/firmware/config.py
+++ b/firmware/config.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2024 RotaryUsb Project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Configuration data structures, defaults, validation, and serialization
+for RotaryUsb Generic HID mode.
+
+This module has no CircuitPython dependencies and can be tested on desktop Python.
+"""
+
+import struct
+
+# Config binary format version
+CONFIG_VERSION = 0x01
+
+# Struct format for one encoder config block (26 bytes, little-endian)
+# int32 min, int32 max, int32 step, uint8 wrap, uint8 reverse,
+# 3x (uint16 threshold, uint16 multiplier)
+ENCODER_CONFIG_STRUCT = struct.Struct("<iiiBBHHHHHH")
+assert ENCODER_CONFIG_STRUCT.size == 26
+
+# Full config: 2-byte header + 4 x 26-byte encoder blocks = 106 bytes
+FULL_CONFIG_SIZE = 106
+
+# Number of encoders
+NUM_ENCODERS = 4
+
+# Number of acceleration tiers
+NUM_TIERS = 3
+
+
+class TierConfig:
+    """Single acceleration tier configuration."""
+    __slots__ = ("threshold_ms", "multiplier")
+
+    def __init__(self, threshold_ms=0, multiplier=1):
+        self.threshold_ms = threshold_ms
+        self.multiplier = multiplier
+
+
+class EncoderConfig:
+    """Configuration for a single encoder."""
+    __slots__ = ("min_value", "max_value", "step_size", "wrap", "reverse", "tiers")
+
+    def __init__(self, min_value=0, max_value=100, step_size=1,
+                 wrap=False, reverse=False, tiers=None):
+        self.min_value = min_value
+        self.max_value = max_value
+        self.step_size = step_size
+        self.wrap = wrap
+        self.reverse = reverse
+        if tiers is None:
+            self.tiers = [TierConfig(), TierConfig(), TierConfig()]
+        else:
+            self.tiers = tiers
+
+    def pack(self):
+        """Pack into 26-byte binary."""
+        return ENCODER_CONFIG_STRUCT.pack(
+            self.min_value, self.max_value, self.step_size,
+            1 if self.wrap else 0,
+            1 if self.reverse else 0,
+            self.tiers[0].threshold_ms, self.tiers[0].multiplier,
+            self.tiers[1].threshold_ms, self.tiers[1].multiplier,
+            self.tiers[2].threshold_ms, self.tiers[2].multiplier,
+        )
+
+    @classmethod
+    def unpack(cls, data):
+        """Unpack from 26-byte binary."""
+        vals = ENCODER_CONFIG_STRUCT.unpack(data)
+        return cls(
+            min_value=vals[0], max_value=vals[1], step_size=vals[2],
+            wrap=bool(vals[3]), reverse=bool(vals[4]),
+            tiers=[
+                TierConfig(vals[5], vals[6]),
+                TierConfig(vals[7], vals[8]),
+                TierConfig(vals[9], vals[10]),
+            ],
+        )
+
+
+class DeviceConfig:
+    """Full device configuration (4 encoders + global flags)."""
+
+    def __init__(self, steps_per_detent_mode=0, encoders=None):
+        self.version = CONFIG_VERSION
+        self.steps_per_detent_mode = steps_per_detent_mode  # 0=4 steps, 1=2 steps
+        if encoders is None:
+            self.encoders = [factory_default_encoder() for _ in range(NUM_ENCODERS)]
+        else:
+            self.encoders = encoders
+
+    def pack(self):
+        """Pack into 106-byte binary."""
+        data = struct.pack("BB", self.version, self.steps_per_detent_mode)
+        for enc in self.encoders:
+            data += enc.pack()
+        assert len(data) == FULL_CONFIG_SIZE
+        return data
+
+    @classmethod
+    def unpack(cls, data):
+        """Unpack from 106-byte binary."""
+        if len(data) != FULL_CONFIG_SIZE:
+            return None
+        version, flags = struct.unpack("BB", data[0:2])
+        if version != CONFIG_VERSION:
+            return None
+        encoders = []
+        for i in range(NUM_ENCODERS):
+            offset = 2 + i * ENCODER_CONFIG_STRUCT.size
+            enc_data = data[offset:offset + ENCODER_CONFIG_STRUCT.size]
+            encoders.append(EncoderConfig.unpack(enc_data))
+        return cls(steps_per_detent_mode=flags & 0x01, encoders=encoders)
+
+
+def factory_default_encoder():
+    """Return factory default encoder config."""
+    return EncoderConfig(
+        min_value=0, max_value=100, step_size=1,
+        wrap=False, reverse=False,
+        tiers=[
+            TierConfig(150, 5),
+            TierConfig(80, 15),
+            TierConfig(40, 50),
+        ],
+    )
+
+
+def factory_default_config():
+    """Return full factory default config."""
+    return DeviceConfig()
+
+
+def validate_encoder_config(enc):
+    """
+    Validate a single encoder config. Returns True if valid.
+    """
+    if enc.min_value >= enc.max_value:
+        return False
+    if enc.step_size <= 0:
+        return False
+
+    # Collect enabled tiers
+    enabled = [(i, enc.tiers[i]) for i in range(NUM_TIERS)
+               if enc.tiers[i].threshold_ms > 0]
+
+    # Check enabled tier thresholds are strictly descending
+    # and multipliers are strictly ascending
+    for j in range(len(enabled) - 1):
+        idx_a, tier_a = enabled[j]
+        idx_b, tier_b = enabled[j + 1]
+        if tier_a.threshold_ms <= tier_b.threshold_ms:
+            return False
+        if tier_a.multiplier >= tier_b.multiplier:
+            return False
+
+    return True
+
+
+def validate_config(config):
+    """Validate a full DeviceConfig. Returns True if valid."""
+    if config is None:
+        return False
+    if config.version != CONFIG_VERSION:
+        return False
+    if len(config.encoders) != NUM_ENCODERS:
+        return False
+    return all(validate_encoder_config(enc) for enc in config.encoders)
+
+
+def clamp_position(position, min_value, max_value, wrap):
+    """Clamp or wrap a position to [min_value, max_value]."""
+    if not wrap:
+        return max(min_value, min(max_value, position))
+
+    range_size = max_value - min_value + 1  # computed as int64 conceptually
+    if position > max_value:
+        position = min_value + ((position - min_value) % range_size)
+    elif position < min_value:
+        position = max_value - ((min_value - 1 - position) % range_size)
+    return position
+
+
+def select_acceleration_tier(interval_ms, tiers):
+    """
+    Select acceleration tier based on time between detents.
+    Returns (tier_index, multiplier) where tier_index 0 = normal speed.
+    """
+    # Check from fastest (tier 3) to slowest (tier 1)
+    for i in range(NUM_TIERS - 1, -1, -1):
+        if tiers[i].threshold_ms > 0 and interval_ms < tiers[i].threshold_ms:
+            return (i + 1, tiers[i].multiplier)
+    return (0, 1)
+
+
+def compute_effective_step(step_size, multiplier):
+    """Compute effective step with overflow protection."""
+    result = step_size * multiplier  # Python handles big ints natively
+    # Clamp to int32 range
+    return max(-2147483648, min(2147483647, result))

--- a/firmware/config.py
+++ b/firmware/config.py
@@ -141,9 +141,13 @@ def validate_encoder_config(enc):
     if enc.step_size <= 0:
         return False
 
-    # Collect enabled tiers
-    enabled = [(i, enc.tiers[i]) for i in range(NUM_TIERS)
-               if enc.tiers[i].threshold_ms > 0]
+    # Collect enabled tiers and check each has a non-zero multiplier
+    enabled = []
+    for i in range(NUM_TIERS):
+        if enc.tiers[i].threshold_ms > 0:
+            if enc.tiers[i].multiplier == 0:
+                return False
+            enabled.append((i, enc.tiers[i]))
 
     # Check enabled tier thresholds are strictly descending
     # and multipliers are strictly ascending

--- a/tests/test_config_logic.py
+++ b/tests/test_config_logic.py
@@ -113,6 +113,20 @@ def test_disabled_middle_tier_valid():
     assert validate_encoder_config(enc)
 
 
+def test_invalid_enabled_tier_zero_multiplier():
+    """Enabled tier with multiplier=0 should be invalid (would freeze encoder)."""
+    enc = factory_default_encoder()
+    enc.tiers[0] = TierConfig(150, 0)  # enabled threshold, but zero multiplier
+    assert not validate_encoder_config(enc)
+
+
+def test_invalid_enabled_tier_zero_multiplier_middle():
+    """Middle tier enabled with multiplier=0 should be invalid."""
+    enc = factory_default_encoder()
+    enc.tiers[1] = TierConfig(80, 0)
+    assert not validate_encoder_config(enc)
+
+
 def test_disabled_middle_tier_invalid_threshold():
     """Tier 2 disabled, but tier3 threshold > tier1 threshold — invalid."""
     enc = factory_default_encoder()

--- a/tests/test_config_logic.py
+++ b/tests/test_config_logic.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: 2024 RotaryUsb Project
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for config validation, serialization, position wrapping, and acceleration."""
+
+import sys
+import os
+
+# Add firmware directory to path so we can import config module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "firmware"))
+
+from config import (
+    EncoderConfig, TierConfig, DeviceConfig,
+    factory_default_config, factory_default_encoder,
+    validate_encoder_config, validate_config,
+    clamp_position, select_acceleration_tier, compute_effective_step,
+    FULL_CONFIG_SIZE,
+)
+
+
+# ---- Serialization round-trip ----
+
+def test_encoder_config_roundtrip():
+    enc = EncoderConfig(
+        min_value=-1000, max_value=1000, step_size=10,
+        wrap=True, reverse=True,
+        tiers=[TierConfig(200, 3), TierConfig(100, 10), TierConfig(50, 50)],
+    )
+    data = enc.pack()
+    assert len(data) == 26
+    restored = EncoderConfig.unpack(data)
+    assert restored.min_value == -1000
+    assert restored.max_value == 1000
+    assert restored.step_size == 10
+    assert restored.wrap is True
+    assert restored.reverse is True
+    assert restored.tiers[0].threshold_ms == 200
+    assert restored.tiers[2].multiplier == 50
+
+
+def test_full_config_roundtrip():
+    config = factory_default_config()
+    data = config.pack()
+    assert len(data) == FULL_CONFIG_SIZE
+    restored = DeviceConfig.unpack(data)
+    assert restored is not None
+    assert restored.version == config.version
+    assert len(restored.encoders) == 4
+    assert restored.encoders[0].max_value == 100
+
+
+def test_unpack_wrong_size_returns_none():
+    assert DeviceConfig.unpack(b"\x00" * 50) is None
+
+
+def test_unpack_wrong_version_returns_none():
+    data = bytearray(FULL_CONFIG_SIZE)
+    data[0] = 0xFF  # wrong version
+    assert DeviceConfig.unpack(bytes(data)) is None
+
+
+# ---- Validation ----
+
+def test_valid_default_config():
+    assert validate_config(factory_default_config())
+
+
+def test_invalid_min_ge_max():
+    enc = factory_default_encoder()
+    enc.min_value = 100
+    enc.max_value = 50
+    assert not validate_encoder_config(enc)
+
+
+def test_invalid_min_eq_max():
+    enc = factory_default_encoder()
+    enc.min_value = 50
+    enc.max_value = 50
+    assert not validate_encoder_config(enc)
+
+
+def test_invalid_step_zero():
+    enc = factory_default_encoder()
+    enc.step_size = 0
+    assert not validate_encoder_config(enc)
+
+
+def test_invalid_step_negative():
+    enc = factory_default_encoder()
+    enc.step_size = -1
+    assert not validate_encoder_config(enc)
+
+
+def test_invalid_tier_thresholds_not_descending():
+    enc = factory_default_encoder()
+    enc.tiers[0].threshold_ms = 80
+    enc.tiers[1].threshold_ms = 150  # tier2 > tier1, wrong
+    assert not validate_encoder_config(enc)
+
+
+def test_invalid_tier_multipliers_not_ascending():
+    enc = factory_default_encoder()
+    enc.tiers[0].multiplier = 20
+    enc.tiers[1].multiplier = 10  # tier2 < tier1, wrong
+    assert not validate_encoder_config(enc)
+
+
+def test_disabled_middle_tier_valid():
+    """Tier 2 disabled, tiers 1 and 3 enabled — should validate tier1 vs tier3."""
+    enc = factory_default_encoder()
+    enc.tiers[0] = TierConfig(150, 5)
+    enc.tiers[1] = TierConfig(0, 0)  # disabled
+    enc.tiers[2] = TierConfig(40, 50)
+    assert validate_encoder_config(enc)
+
+
+def test_disabled_middle_tier_invalid_threshold():
+    """Tier 2 disabled, but tier3 threshold > tier1 threshold — invalid."""
+    enc = factory_default_encoder()
+    enc.tiers[0] = TierConfig(50, 5)
+    enc.tiers[1] = TierConfig(0, 0)  # disabled
+    enc.tiers[2] = TierConfig(100, 50)  # threshold > tier1
+    assert not validate_encoder_config(enc)
+
+
+def test_all_tiers_disabled_valid():
+    enc = factory_default_encoder()
+    enc.tiers = [TierConfig(0, 0), TierConfig(0, 0), TierConfig(0, 0)]
+    assert validate_encoder_config(enc)
+
+
+def test_large_mhz_values_valid():
+    enc = EncoderConfig(
+        min_value=88000, max_value=108000, step_size=100,
+        wrap=True, reverse=False,
+        tiers=[TierConfig(150, 10), TierConfig(80, 100), TierConfig(40, 1000)],
+    )
+    assert validate_encoder_config(enc)
+
+
+# ---- Position clamping and wrapping ----
+
+def test_clamp_within_range():
+    assert clamp_position(50, 0, 100, wrap=False) == 50
+
+
+def test_clamp_above_max():
+    assert clamp_position(150, 0, 100, wrap=False) == 100
+
+
+def test_clamp_below_min():
+    assert clamp_position(-10, 0, 100, wrap=False) == 0
+
+
+def test_wrap_above_max():
+    # 0-9 range (10 values), position=10 wraps to 0
+    assert clamp_position(10, 0, 9, wrap=True) == 0
+
+
+def test_wrap_above_max_by_two():
+    assert clamp_position(11, 0, 9, wrap=True) == 1
+
+
+def test_wrap_below_min():
+    # position=-1 wraps to 9
+    assert clamp_position(-1, 0, 9, wrap=True) == 9
+
+
+def test_wrap_below_min_by_two():
+    assert clamp_position(-2, 0, 9, wrap=True) == 8
+
+
+def test_wrap_exact_range_below():
+    # position=-10 wraps to 0 (full cycle)
+    assert clamp_position(-10, 0, 9, wrap=True) == 0
+
+
+def test_wrap_negative_range():
+    # min=-50, max=50, position=51 wraps to -50
+    assert clamp_position(51, -50, 50, wrap=True) == -50
+
+
+def test_wrap_large_mhz_values():
+    # Radio tuner: 88000-108000, step over max
+    assert clamp_position(108001, 88000, 108000, wrap=True) == 88000
+    assert clamp_position(87999, 88000, 108000, wrap=True) == 108000
+
+
+# ---- Acceleration tier selection ----
+
+def test_normal_speed():
+    tiers = [TierConfig(150, 5), TierConfig(80, 15), TierConfig(40, 50)]
+    tier_idx, mult = select_acceleration_tier(200, tiers)
+    assert tier_idx == 0
+    assert mult == 1
+
+
+def test_tier1_speed():
+    tiers = [TierConfig(150, 5), TierConfig(80, 15), TierConfig(40, 50)]
+    tier_idx, mult = select_acceleration_tier(100, tiers)
+    assert tier_idx == 1
+    assert mult == 5
+
+
+def test_tier2_speed():
+    tiers = [TierConfig(150, 5), TierConfig(80, 15), TierConfig(40, 50)]
+    tier_idx, mult = select_acceleration_tier(60, tiers)
+    assert tier_idx == 2
+    assert mult == 15
+
+
+def test_tier3_speed():
+    tiers = [TierConfig(150, 5), TierConfig(80, 15), TierConfig(40, 50)]
+    tier_idx, mult = select_acceleration_tier(30, tiers)
+    assert tier_idx == 3
+    assert mult == 50
+
+
+def test_disabled_middle_tier_skipped():
+    tiers = [TierConfig(150, 5), TierConfig(0, 0), TierConfig(40, 50)]
+    # 60ms: tier3 disabled check (40ms, 60>40 so no), tier2 disabled, tier1 (150ms, 60<150 so yes)
+    tier_idx, mult = select_acceleration_tier(60, tiers)
+    assert tier_idx == 1
+    assert mult == 5
+
+
+def test_all_tiers_disabled():
+    tiers = [TierConfig(0, 0), TierConfig(0, 0), TierConfig(0, 0)]
+    tier_idx, mult = select_acceleration_tier(10, tiers)
+    assert tier_idx == 0
+    assert mult == 1
+
+
+# ---- Effective step computation ----
+
+def test_effective_step_normal():
+    assert compute_effective_step(100, 10) == 1000
+
+
+def test_effective_step_overflow_clamps():
+    assert compute_effective_step(2000000000, 2) == 2147483647  # INT32_MAX
+
+
+def test_effective_step_negative_overflow():
+    assert compute_effective_step(-2000000000, 2) == -2147483648  # INT32_MIN
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])

--- a/windows-example/Program.cs
+++ b/windows-example/Program.cs
@@ -320,9 +320,9 @@ public class Program
                                 $"UsagePage:0x{caps.UsagePage:X4} Usage:0x{caps.Usage:X2}");
 
                 bool vidMatch = KNOWN_VIDS.Contains(attrs.VendorId);
-                bool isVendorPage = caps.UsagePage == VENDOR_USAGE_PAGE;
+                bool pidMatch = KNOWN_PIDS.Contains(attrs.ProductId);
 
-                if (isVendorPage && (vidMatch || attrs.VendorId != 0))
+                if (vidMatch && pidMatch)
                 {
                     Console.WriteLine($"  -> RotaryUsb device found!");
                     return device;
@@ -682,6 +682,12 @@ public class Program
                     EditTier(working.Tiers[2], "Tier 3");
                     break;
                 case 'A':
+                    var validationError = ValidateEncoderConfig(working);
+                    if (validationError != null)
+                    {
+                        Console.WriteLine($"  Validation error: {validationError}");
+                        break;
+                    }
                     lock (_lock)
                     {
                         _deviceConfig.Encoders[encIdx] = working;
@@ -712,6 +718,38 @@ public class Program
         if (int.TryParse(input, out int value)) return value;
         Console.WriteLine("  Invalid number, keeping current value.");
         return current;
+    }
+
+    private static string? ValidateEncoderConfig(EncoderConfig enc)
+    {
+        if (enc.MinValue >= enc.MaxValue)
+            return $"min ({enc.MinValue}) must be less than max ({enc.MaxValue})";
+        if (enc.StepSize <= 0)
+            return $"step size ({enc.StepSize}) must be positive";
+
+        // Check enabled tiers
+        ushort prevThreshold = 0;
+        ushort prevMultiplier = 0;
+        bool hasPrev = false;
+        for (int i = 0; i < NUM_TIERS; i++)
+        {
+            if (enc.Tiers[i].ThresholdMs > 0)
+            {
+                if (enc.Tiers[i].Multiplier == 0)
+                    return $"tier {i + 1} has threshold but multiplier is 0";
+                if (hasPrev)
+                {
+                    if (enc.Tiers[i].ThresholdMs >= prevThreshold)
+                        return $"tier {i + 1} threshold must be less than previous enabled tier";
+                    if (enc.Tiers[i].Multiplier <= prevMultiplier)
+                        return $"tier {i + 1} multiplier must be greater than previous enabled tier";
+                }
+                prevThreshold = enc.Tiers[i].ThresholdMs;
+                prevMultiplier = enc.Tiers[i].Multiplier;
+                hasPrev = true;
+            }
+        }
+        return null;
     }
 
     private static void EditTier(TierConfig tier, string name)

--- a/windows-example/Program.cs
+++ b/windows-example/Program.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -10,41 +11,208 @@ using HidLibrary;
 namespace RotaryUsbExample;
 
 /// <summary>
-/// Example Windows console application demonstrating two methods to read
-/// RotaryUsb device data:
-/// 
-/// 1. GENERIC HID MODE (Recommended): Direct HID access using HidLibrary
-///    - Requires firmware in Generic HID mode (boot.py + code_generic_hid.py)
-///    - Reads raw encoder/button data directly
-///    - Events only go to your application
-/// 
-/// 2. KEYBOARD HID MODE: Low-level keyboard hook
-///    - Works with default firmware (code.py only)
-///    - Intercepts F1-F12 key events
-///    - Keys are sent to all applications
+/// Windows console application for RotaryUsb device with runtime configuration.
+///
+/// Supports two modes:
+/// 1. GENERIC HID MODE (Recommended): Direct HID access with config menu
+/// 2. KEYBOARD HID MODE: Low-level keyboard hook for F1-F12 keys
 /// </summary>
 public class Program
 {
     // ========================================================================
     // GENERIC HID CONFIGURATION
     // ========================================================================
-    
-    // CircuitPython devices typically use Adafruit VID
-    // Check Device Manager or use the enumeration to find your actual VID/PID
-    private static readonly int[] KNOWN_VIDS = { 0x239A, 0xCAFE };  // Adafruit, Development
-    private static readonly int[] KNOWN_PIDS = { 0x80F4, 0x4005 }; // CircuitPython, C++ Generic HID
-    
-    // Vendor-defined Usage Page for Generic HID mode
-    // Note: HidLibrary returns UsagePage as short, so 0xFF00 becomes -256 when signed
+
+    private static readonly int[] KNOWN_VIDS = { 0x239A, 0xCAFE };
+    private static readonly int[] KNOWN_PIDS = { 0x80F4, 0x4005 };
     private const short VENDOR_USAGE_PAGE = unchecked((short)0xFF00);
-    
+
+    // Config constants
+    private const byte CONFIG_VERSION = 0x01;
+    private const int FULL_CONFIG_SIZE = 106;
+    private const int NUM_ENCODERS = 4;
+    private const int NUM_TIERS = 3;
+
+    // Report IDs
+    private const byte REPORT_ID_POSITIONS = 0x01;
+    private const byte REPORT_ID_CONFIG = 0x02;
+    private const byte REPORT_ID_COMMAND = 0x03;
+
+    // Commands
+    private const byte CMD_SAVE_CONFIG = 0x01;
+    private const byte CMD_RESET_DEFAULTS = 0x02;
+    private const byte CMD_RESET_POSITIONS = 0x03;
+    private const byte CMD_READ_CONFIG = 0x04;
+
+    // ========================================================================
+    // CONFIG DATA STRUCTURES
+    // ========================================================================
+
+    private class TierConfig
+    {
+        public ushort ThresholdMs;
+        public ushort Multiplier;
+    }
+
+    private class EncoderConfig
+    {
+        public int MinValue;
+        public int MaxValue;
+        public int StepSize;
+        public bool Wrap;
+        public bool Reverse;
+        public TierConfig[] Tiers = new TierConfig[NUM_TIERS];
+
+        public EncoderConfig()
+        {
+            for (int i = 0; i < NUM_TIERS; i++)
+                Tiers[i] = new TierConfig();
+        }
+
+        public EncoderConfig Clone()
+        {
+            var c = new EncoderConfig
+            {
+                MinValue = MinValue,
+                MaxValue = MaxValue,
+                StepSize = StepSize,
+                Wrap = Wrap,
+                Reverse = Reverse
+            };
+            for (int i = 0; i < NUM_TIERS; i++)
+            {
+                c.Tiers[i] = new TierConfig
+                {
+                    ThresholdMs = Tiers[i].ThresholdMs,
+                    Multiplier = Tiers[i].Multiplier
+                };
+            }
+            return c;
+        }
+    }
+
+    private class DeviceConfig
+    {
+        public byte Version = CONFIG_VERSION;
+        public byte GlobalFlags;
+        public EncoderConfig[] Encoders = new EncoderConfig[NUM_ENCODERS];
+
+        public DeviceConfig()
+        {
+            for (int i = 0; i < NUM_ENCODERS; i++)
+                Encoders[i] = new EncoderConfig();
+        }
+
+        public byte[] Serialize()
+        {
+            var data = new byte[FULL_CONFIG_SIZE];
+            data[0] = Version;
+            data[1] = GlobalFlags;
+            int offset = 2;
+            for (int e = 0; e < NUM_ENCODERS; e++)
+            {
+                var enc = Encoders[e];
+                BitConverter.GetBytes(enc.MinValue).CopyTo(data, offset);
+                BitConverter.GetBytes(enc.MaxValue).CopyTo(data, offset + 4);
+                BitConverter.GetBytes(enc.StepSize).CopyTo(data, offset + 8);
+                data[offset + 12] = (byte)(enc.Wrap ? 1 : 0);
+                data[offset + 13] = (byte)(enc.Reverse ? 1 : 0);
+                for (int t = 0; t < NUM_TIERS; t++)
+                {
+                    BitConverter.GetBytes(enc.Tiers[t].ThresholdMs).CopyTo(data, offset + 14 + t * 4);
+                    BitConverter.GetBytes(enc.Tiers[t].Multiplier).CopyTo(data, offset + 16 + t * 4);
+                }
+                offset += 26;
+            }
+            return data;
+        }
+
+        public static DeviceConfig? Deserialize(byte[] data)
+        {
+            if (data.Length < FULL_CONFIG_SIZE) return null;
+            if (data[0] != CONFIG_VERSION) return null;
+
+            var cfg = new DeviceConfig
+            {
+                Version = data[0],
+                GlobalFlags = data[1]
+            };
+            int offset = 2;
+            for (int e = 0; e < NUM_ENCODERS; e++)
+            {
+                var enc = new EncoderConfig
+                {
+                    MinValue = BitConverter.ToInt32(data, offset),
+                    MaxValue = BitConverter.ToInt32(data, offset + 4),
+                    StepSize = BitConverter.ToInt32(data, offset + 8),
+                    Wrap = data[offset + 12] != 0,
+                    Reverse = data[offset + 13] != 0
+                };
+                for (int t = 0; t < NUM_TIERS; t++)
+                {
+                    enc.Tiers[t] = new TierConfig
+                    {
+                        ThresholdMs = BitConverter.ToUInt16(data, offset + 14 + t * 4),
+                        Multiplier = BitConverter.ToUInt16(data, offset + 16 + t * 4)
+                    };
+                }
+                cfg.Encoders[e] = enc;
+                offset += 26;
+            }
+            return cfg;
+        }
+    }
+
+    // ========================================================================
+    // PRESETS
+    // ========================================================================
+
+    private static readonly Dictionary<string, EncoderConfig> Presets = new()
+    {
+        ["General Purpose"] = CreatePreset(0, 100, 1, false, false,
+            150, 5, 80, 15, 40, 50),
+        ["Radio Tuner (kHz)"] = CreatePreset(88000, 108000, 100, true, false,
+            150, 10, 80, 100, 40, 1000),
+        ["Audio Mixer (%)"] = CreatePreset(0, 100, 1, false, false,
+            150, 2, 80, 5, 40, 10),
+        ["Fine Control"] = CreatePreset(0, 10000, 1, false, false,
+            150, 5, 80, 25, 40, 100),
+    };
+
+    private static EncoderConfig CreatePreset(int min, int max, int step, bool wrap, bool reverse,
+        ushort t1Thresh, ushort t1Mult, ushort t2Thresh, ushort t2Mult, ushort t3Thresh, ushort t3Mult)
+    {
+        return new EncoderConfig
+        {
+            MinValue = min, MaxValue = max, StepSize = step,
+            Wrap = wrap, Reverse = reverse,
+            Tiers = new[]
+            {
+                new TierConfig { ThresholdMs = t1Thresh, Multiplier = t1Mult },
+                new TierConfig { ThresholdMs = t2Thresh, Multiplier = t2Mult },
+                new TierConfig { ThresholdMs = t3Thresh, Multiplier = t3Mult },
+            }
+        };
+    }
+
+    // ========================================================================
+    // STATE
+    // ========================================================================
+
+    private static DeviceConfig _deviceConfig = new();
+    private static int[] _encoderPositions = new int[NUM_ENCODERS];
+    private static byte _tierByte;
+    private static byte _buttonStates;
+    private static HidDevice? _hidDevice;
+    private static bool _configReceived;
+    private static readonly object _lock = new();
+
     // ========================================================================
     // KEYBOARD HOOK CONFIGURATION (for Keyboard HID mode)
     // ========================================================================
-    
+
     private const int WH_KEYBOARD_LL = 13;
     private const int WM_KEYDOWN = 0x0100;
-    private const int WM_KEYUP = 0x0101;
 
     private const int VK_F1 = 0x70;
     private const int VK_F2 = 0x71;
@@ -63,7 +231,6 @@ public class Program
     private static LowLevelKeyboardProc? _hookCallback;
     private static IntPtr _hookId = IntPtr.Zero;
 
-    // P/Invoke declarations
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
 
@@ -90,32 +257,13 @@ public class Program
     private static extern void PostQuitMessage(int nExitCode);
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct MSG
-    {
-        public IntPtr hwnd;
-        public uint message;
-        public IntPtr wParam;
-        public IntPtr lParam;
-        public uint time;
-        public POINT pt;
-    }
+    private struct MSG { public IntPtr hwnd; public uint message; public IntPtr wParam; public IntPtr lParam; public uint time; public POINT pt; }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct POINT
-    {
-        public int x;
-        public int y;
-    }
+    private struct POINT { public int x; public int y; }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct KBDLLHOOKSTRUCT
-    {
-        public uint vkCode;
-        public uint scanCode;
-        public uint flags;
-        public uint time;
-        public IntPtr dwExtraInfo;
-    }
+    private struct KBDLLHOOKSTRUCT { public uint vkCode; public uint scanCode; public uint flags; public uint time; public IntPtr dwExtraInfo; }
 
     // ========================================================================
     // MAIN ENTRY POINT
@@ -126,17 +274,12 @@ public class Program
         Console.WriteLine("RotaryUsb Windows Example");
         Console.WriteLine("=========================");
         Console.WriteLine();
-        Console.WriteLine("This application supports two modes:");
-        Console.WriteLine("  1. Generic HID Mode - Direct device access (recommended)");
-        Console.WriteLine("  2. Keyboard HID Mode - Keyboard hook for F1-F12 keys");
-        Console.WriteLine();
-        
-        // Try Generic HID mode first
+
         var hidDevice = FindGenericHidDevice();
-        
+
         if (hidDevice != null)
         {
-            Console.WriteLine("Generic HID device found! Starting Generic HID mode...");
+            Console.WriteLine("Generic HID device found! Starting...");
             Console.WriteLine();
             RunGenericHidMode(hidDevice);
         }
@@ -145,44 +288,28 @@ public class Program
             Console.WriteLine("No Generic HID device found.");
             Console.WriteLine("Falling back to Keyboard HID mode...");
             Console.WriteLine();
-            Console.WriteLine("Note: For Generic HID mode, ensure the firmware is configured");
-            Console.WriteLine("with boot.py and code_generic_hid.py");
-            Console.WriteLine();
             RunKeyboardHidMode();
         }
     }
 
     // ========================================================================
-    // GENERIC HID MODE IMPLEMENTATION
+    // GENERIC HID MODE — DEVICE DISCOVERY
     // ========================================================================
 
-    /// <summary>
-    /// Find a RotaryUsb device configured for Generic HID mode.
-    /// </summary>
     private static HidDevice? FindGenericHidDevice()
     {
         Console.WriteLine("Searching for Generic HID devices...");
-        
-        // Get all HID devices
         var allDevices = HidDevices.Enumerate().ToList();
         Console.WriteLine($"Found {allDevices.Count} HID devices total.");
-        
-        // Look for vendor-defined devices (Usage Page 0xFF00)
-        var vendorDevices = allDevices.Where(d => 
+
+        var vendorDevices = allDevices.Where(d =>
         {
-            try
-            {
-                var caps = d.Capabilities;
-                return caps.UsagePage == VENDOR_USAGE_PAGE;
-            }
-            catch
-            {
-                return false;
-            }
+            try { return d.Capabilities.UsagePage == VENDOR_USAGE_PAGE; }
+            catch { return false; }
         }).ToList();
-        
+
         Console.WriteLine($"Found {vendorDevices.Count} vendor-defined HID devices.");
-        
+
         foreach (var device in vendorDevices)
         {
             try
@@ -191,14 +318,13 @@ public class Program
                 var caps = device.Capabilities;
                 Console.WriteLine($"  - VID:0x{attrs.VendorId:X4} PID:0x{attrs.ProductId:X4} " +
                                 $"UsagePage:0x{caps.UsagePage:X4} Usage:0x{caps.Usage:X2}");
-                
-                // Check if this matches known RotaryUsb identifiers
+
                 bool vidMatch = KNOWN_VIDS.Contains(attrs.VendorId);
                 bool isVendorPage = caps.UsagePage == VENDOR_USAGE_PAGE;
-                
+
                 if (isVendorPage && (vidMatch || attrs.VendorId != 0))
                 {
-                    Console.WriteLine($"  -> Potential RotaryUsb device found!");
+                    Console.WriteLine($"  -> RotaryUsb device found!");
                     return device;
                 }
             }
@@ -207,130 +333,54 @@ public class Program
                 Console.WriteLine($"  - Error reading device: {ex.Message}");
             }
         }
-        
-        // Also list any devices matching known VIDs regardless of usage page
-        Console.WriteLine();
-        Console.WriteLine("Devices matching known VIDs:");
-        foreach (var device in allDevices)
-        {
-            try
-            {
-                var attrs = device.Attributes;
-                if (KNOWN_VIDS.Contains(attrs.VendorId))
-                {
-                    var caps = device.Capabilities;
-                    Console.WriteLine($"  - VID:0x{attrs.VendorId:X4} PID:0x{attrs.ProductId:X4} " +
-                                    $"UsagePage:0x{caps.UsagePage:X4} Usage:0x{caps.Usage:X2}");
-                }
-            }
-            catch { }
-        }
-        
+
         return null;
     }
 
-    /// <summary>
-    /// Run in Generic HID mode, reading raw encoder data from the device.
-    /// </summary>
+    // ========================================================================
+    // GENERIC HID MODE — MAIN LOOP
+    // ========================================================================
+
     private static void RunGenericHidMode(HidDevice device)
     {
-        Console.WriteLine("Generic HID Mode");
-        Console.WriteLine("================");
-        Console.WriteLine();
-        Console.WriteLine("HID Report Format:");
-        Console.WriteLine("  Byte 0: Report ID (0x01)");
-        Console.WriteLine("  Byte 1-4: Encoder 1-4 movement (signed, +CW/-CCW)");
-        Console.WriteLine("  Byte 5: Button states (bit 0-3 = buttons 1-4)");
-        Console.WriteLine("  Byte 6-7: Reserved");
-        Console.WriteLine();
-        Console.WriteLine("Press Ctrl+C to exit.");
-        Console.WriteLine();
-        Console.WriteLine("Waiting for HID reports...");
-        Console.WriteLine("-".PadRight(60, '-'));
-
-        // Track encoder positions (accumulated from relative movements)
-        int[] encoderPositions = new int[4];
-        bool[] lastButtonStates = new bool[4];
-
-        // Handle Ctrl+C
-        var cts = new CancellationTokenSource();
-        Console.CancelKeyPress += (sender, e) =>
-        {
-            e.Cancel = true;
-            Console.WriteLine("\nShutting down...");
-            cts.Cancel();
-        };
+        _hidDevice = device;
 
         try
         {
             device.OpenDevice();
-            
             if (!device.IsConnected)
             {
                 Console.WriteLine("ERROR: Failed to open device.");
                 return;
             }
 
-            Console.WriteLine("Device opened successfully.");
-            Console.WriteLine();
-
-            // Read reports continuously
             device.MonitorDeviceEvents = true;
-            
-            while (!cts.Token.IsCancellationRequested)
+
+            // Request current config from device
+            Console.WriteLine("Reading config from device...");
+            SendCommand(CMD_READ_CONFIG);
+
+            // Start background reader thread
+            var cts = new CancellationTokenSource();
+            var readerThread = new Thread(() => ReportReaderLoop(device, cts.Token))
             {
-                var report = device.Read(100); // 100ms timeout
-                
-                if (report.Status == HidDeviceData.ReadStatus.Success && report.Data.Length >= 7)
-                {
-                    // Parse the report
-                    // HidLibrary prepends a report ID byte to the data, so the first byte is always the Report ID (0x01)
-                    // Our actual data starts at index 1
-                    int offset = (report.Data.Length >= 8 && report.Data[0] == 0x01) ? 1 : 0;
-                    
-                    // Read encoder movements (signed bytes)
-                    for (int i = 0; i < 4; i++)
-                    {
-                        sbyte movement = (sbyte)report.Data[offset + i];
-                        if (movement != 0)
-                        {
-                            encoderPositions[i] += movement;
-                            string direction = movement > 0 ? "CW" : "CCW";
-                            Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] Encoder {i + 1}: {direction} ({movement:+#;-#;0}) -> Position: {encoderPositions[i]}");
-                            
-                            // Example action handling
-                            HandleEncoderMovement(i + 1, movement, encoderPositions[i]);
-                        }
-                    }
-                    
-                    // Read button states
-                    byte buttonByte = report.Data[offset + 4];
-                    for (int i = 0; i < 4; i++)
-                    {
-                        bool pressed = (buttonByte & (1 << i)) != 0;
-                        if (pressed != lastButtonStates[i])
-                        {
-                            lastButtonStates[i] = pressed;
-                            string state = pressed ? "PRESSED" : "RELEASED";
-                            Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] Button {i + 1}: {state}");
-                            
-                            if (pressed)
-                            {
-                                HandleButtonPress(i + 1);
-                            }
-                        }
-                    }
-                }
-                else if (report.Status == HidDeviceData.ReadStatus.WaitTimedOut)
-                {
-                    // Normal timeout, continue
-                }
-                else if (report.Status != HidDeviceData.ReadStatus.Success)
-                {
-                    Console.WriteLine($"Read error: {report.Status}");
-                    Thread.Sleep(100);
-                }
+                IsBackground = true
+            };
+            readerThread.Start();
+
+            // Wait briefly for config readback
+            Thread.Sleep(500);
+            if (!_configReceived)
+            {
+                Console.WriteLine("No config readback received, using defaults.");
+                _deviceConfig = CreateDefaultConfig();
             }
+
+            // Main menu loop
+            RunMainMenu(device, cts);
+
+            cts.Cancel();
+            readerThread.Join(1000);
         }
         catch (Exception ex)
         {
@@ -343,58 +393,367 @@ public class Program
         }
     }
 
-    /// <summary>
-    /// Handle encoder movement - customize this for your application.
-    /// </summary>
-    private static void HandleEncoderMovement(int encoderNumber, int movement, int position)
+    private static DeviceConfig CreateDefaultConfig()
     {
-        // Example: Different actions based on encoder number
-        switch (encoderNumber)
+        var cfg = new DeviceConfig();
+        var preset = Presets["General Purpose"];
+        for (int i = 0; i < NUM_ENCODERS; i++)
+            cfg.Encoders[i] = preset.Clone();
+        return cfg;
+    }
+
+    // ========================================================================
+    // REPORT READER (background thread)
+    // ========================================================================
+
+    private static void ReportReaderLoop(HidDevice device, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested && device.IsConnected)
         {
-            case 1:
-                Console.WriteLine($"  -> Action: Encoder 1 could control volume ({(movement > 0 ? "up" : "down")})");
-                break;
-            case 2:
-                Console.WriteLine($"  -> Action: Encoder 2 could control brightness");
-                break;
-            case 3:
-                Console.WriteLine($"  -> Action: Encoder 3 could scroll content");
-                break;
-            case 4:
-                Console.WriteLine($"  -> Action: Encoder 4 could adjust zoom level");
-                break;
+            var report = device.Read(100);
+            if (report.Status != HidDeviceData.ReadStatus.Success || report.Data.Length < 2)
+                continue;
+
+            byte reportId = report.Data[0];
+
+            if (reportId == REPORT_ID_POSITIONS && report.Data.Length >= 22)
+            {
+                // Input Report ID 0x01: 21 bytes of position data
+                // HidLibrary prepends report ID, so data[1..21] is payload
+                lock (_lock)
+                {
+                    for (int i = 0; i < NUM_ENCODERS; i++)
+                        _encoderPositions[i] = BitConverter.ToInt32(report.Data, 1 + i * 4);
+                    _buttonStates = report.Data[17];
+                    _tierByte = report.Data[18];
+                }
+            }
+            else if (reportId == REPORT_ID_CONFIG && report.Data.Length >= FULL_CONFIG_SIZE + 1)
+            {
+                // Input Report ID 0x02: 106 bytes config readback
+                var configData = new byte[FULL_CONFIG_SIZE];
+                Array.Copy(report.Data, 1, configData, 0, FULL_CONFIG_SIZE);
+                var parsed = DeviceConfig.Deserialize(configData);
+                if (parsed != null)
+                {
+                    lock (_lock)
+                    {
+                        _deviceConfig = parsed;
+                        _configReceived = true;
+                    }
+                }
+            }
         }
     }
 
-    /// <summary>
-    /// Handle button press - customize this for your application.
-    /// </summary>
-    private static void HandleButtonPress(int buttonNumber)
+    // ========================================================================
+    // HID COMMUNICATION
+    // ========================================================================
+
+    private static void SendConfig(DeviceConfig config)
     {
-        switch (buttonNumber)
+        if (_hidDevice == null) return;
+        var payload = config.Serialize();
+        // HidLibrary Write: first byte is report ID
+        var data = new byte[FULL_CONFIG_SIZE + 1];
+        data[0] = REPORT_ID_CONFIG;
+        Array.Copy(payload, 0, data, 1, FULL_CONFIG_SIZE);
+        _hidDevice.Write(data);
+    }
+
+    private static void SendCommand(byte command)
+    {
+        if (_hidDevice == null) return;
+        // Report ID + 2 bytes payload
+        var data = new byte[3];
+        data[0] = REPORT_ID_COMMAND;
+        data[1] = command;
+        data[2] = 0x00;
+        _hidDevice.Write(data);
+    }
+
+    // ========================================================================
+    // MAIN MENU
+    // ========================================================================
+
+    private static void RunMainMenu(HidDevice device, CancellationTokenSource cts)
+    {
+        while (!cts.IsCancellationRequested && device.IsConnected)
         {
-            case 1:
-                Console.WriteLine($"  -> Action: Button 1 could toggle mute");
-                break;
-            case 2:
-                Console.WriteLine($"  -> Action: Button 2 could reset brightness");
-                break;
-            case 3:
-                Console.WriteLine($"  -> Action: Button 3 could toggle scroll lock");
-                break;
-            case 4:
-                Console.WriteLine($"  -> Action: Button 4 could reset zoom to 100%");
-                break;
+            Console.Clear();
+            Console.WriteLine("RotaryUsb Configuration");
+            Console.WriteLine("========================");
+
+            var attrs = device.Attributes;
+            Console.WriteLine($"Device connected: VID:0x{attrs.VendorId:X4} PID:0x{attrs.ProductId:X4}");
+            Console.WriteLine();
+
+            lock (_lock)
+            {
+                Console.WriteLine("Current encoder values:");
+                for (int i = 0; i < NUM_ENCODERS; i++)
+                {
+                    var enc = _deviceConfig.Encoders[i];
+                    int tier = (_tierByte >> (i * 2)) & 0x03;
+                    string tierStr = tier > 0 ? $"  {new string('*', tier)} Tier {tier}" : "";
+                    Console.WriteLine($"  Enc{i + 1}: {_encoderPositions[i],10}  [{enc.MinValue} - {enc.MaxValue}, step={enc.StepSize}]{tierStr}");
+                }
+                Console.WriteLine();
+                Console.Write("  Buttons: ");
+                for (int i = 0; i < NUM_ENCODERS; i++)
+                {
+                    bool pressed = (_buttonStates & (1 << i)) != 0;
+                    Console.Write(pressed ? "[X] " : "[ ] ");
+                }
+                Console.WriteLine();
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("[M] Monitor - Live display of encoder values");
+            Console.WriteLine("[C] Configure encoder");
+            Console.WriteLine("[S] Save config to device flash");
+            Console.WriteLine("[D] Reset to defaults");
+            Console.WriteLine("[R] Reset positions");
+            Console.WriteLine("[Q] Quit");
+            Console.Write("\nChoice: ");
+
+            var key = Console.ReadKey(true);
+            switch (char.ToUpper(key.KeyChar))
+            {
+                case 'M':
+                    RunMonitor(device, cts.Token);
+                    break;
+                case 'C':
+                    RunConfigureEncoder(device);
+                    break;
+                case 'S':
+                    SendCommand(CMD_SAVE_CONFIG);
+                    Console.WriteLine("\nConfig save command sent.");
+                    Thread.Sleep(1000);
+                    break;
+                case 'D':
+                    SendCommand(CMD_RESET_DEFAULTS);
+                    Console.WriteLine("\nReset to defaults command sent.");
+                    Thread.Sleep(500);
+                    SendCommand(CMD_READ_CONFIG);
+                    Thread.Sleep(500);
+                    break;
+                case 'R':
+                    SendCommand(CMD_RESET_POSITIONS);
+                    Console.WriteLine("\nReset positions command sent.");
+                    Thread.Sleep(1000);
+                    break;
+                case 'Q':
+                    return;
+            }
         }
+    }
+
+    // ========================================================================
+    // LIVE MONITOR
+    // ========================================================================
+
+    private static void RunMonitor(HidDevice device, CancellationToken ct)
+    {
+        Console.Clear();
+        Console.WriteLine("Live Monitor (press any key to return)");
+        Console.WriteLine("=======================================");
+
+        while (!ct.IsCancellationRequested && device.IsConnected && !Console.KeyAvailable)
+        {
+            Console.SetCursorPosition(0, 2);
+
+            lock (_lock)
+            {
+                for (int i = 0; i < NUM_ENCODERS; i++)
+                {
+                    var enc = _deviceConfig.Encoders[i];
+                    int tier = (_tierByte >> (i * 2)) & 0x03;
+                    string tierStr = tier switch
+                    {
+                        1 => "  * Tier 1",
+                        2 => "  ** Tier 2",
+                        3 => "  *** Tier 3",
+                        _ => ""
+                    };
+                    Console.WriteLine($"Enc{i + 1}: {_encoderPositions[i],10}  [{enc.MinValue}-{enc.MaxValue}]{tierStr,-20}");
+                }
+
+                Console.WriteLine();
+                Console.Write("Buttons: ");
+                for (int i = 0; i < NUM_ENCODERS; i++)
+                {
+                    bool pressed = (_buttonStates & (1 << i)) != 0;
+                    Console.Write(pressed ? "[X] " : "[ ] ");
+                }
+                Console.WriteLine("          ");
+            }
+
+            Thread.Sleep(50);
+        }
+
+        if (Console.KeyAvailable)
+            Console.ReadKey(true); // consume the key
+    }
+
+    // ========================================================================
+    // CONFIGURE ENCODER
+    // ========================================================================
+
+    private static void RunConfigureEncoder(HidDevice device)
+    {
+        Console.Clear();
+        Console.WriteLine("Configure Encoder");
+        Console.WriteLine("=================");
+        Console.Write("Select encoder [1-4]: ");
+
+        var k = Console.ReadKey(true);
+        int encIdx = k.KeyChar - '1';
+        if (encIdx < 0 || encIdx >= NUM_ENCODERS)
+        {
+            Console.WriteLine("\nInvalid encoder number.");
+            Thread.Sleep(1000);
+            return;
+        }
+        Console.WriteLine(k.KeyChar);
+
+        EncoderConfig working;
+        lock (_lock)
+        {
+            working = _deviceConfig.Encoders[encIdx].Clone();
+        }
+
+        while (true)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Encoder {encIdx + 1} current config:");
+            Console.WriteLine($"  Min: {working.MinValue}  Max: {working.MaxValue}  Step: {working.StepSize}  " +
+                            $"Wrap: {(working.Wrap ? "Yes" : "No")}  Reverse: {(working.Reverse ? "Yes" : "No")}");
+            Console.Write("  ");
+            for (int t = 0; t < NUM_TIERS; t++)
+            {
+                var tier = working.Tiers[t];
+                if (tier.ThresholdMs > 0)
+                    Console.Write($"Tier {t + 1}: <{tier.ThresholdMs}ms -> {tier.Multiplier}x    ");
+                else
+                    Console.Write($"Tier {t + 1}: disabled    ");
+            }
+            Console.WriteLine();
+            Console.WriteLine();
+
+            Console.WriteLine("[1] Min value          [5] Reverse");
+            Console.WriteLine("[2] Max value          [6] Tier 1 (threshold, multiplier)");
+            Console.WriteLine("[3] Step size          [7] Tier 2");
+            Console.WriteLine("[4] Wrap on/off        [8] Tier 3");
+            Console.WriteLine("[A] Apply (send to device)");
+            Console.WriteLine("[P] Load preset");
+            Console.WriteLine("[B] Back");
+            Console.Write("\nChoice: ");
+
+            var choice = Console.ReadKey(true);
+            Console.WriteLine(choice.KeyChar);
+
+            switch (char.ToUpper(choice.KeyChar))
+            {
+                case '1':
+                    working.MinValue = ReadInt("Min value", working.MinValue);
+                    break;
+                case '2':
+                    working.MaxValue = ReadInt("Max value", working.MaxValue);
+                    break;
+                case '3':
+                    working.StepSize = ReadInt("Step size", working.StepSize);
+                    break;
+                case '4':
+                    working.Wrap = !working.Wrap;
+                    Console.WriteLine($"  Wrap: {(working.Wrap ? "Yes" : "No")}");
+                    break;
+                case '5':
+                    working.Reverse = !working.Reverse;
+                    Console.WriteLine($"  Reverse: {(working.Reverse ? "Yes" : "No")}");
+                    break;
+                case '6':
+                    EditTier(working.Tiers[0], "Tier 1");
+                    break;
+                case '7':
+                    EditTier(working.Tiers[1], "Tier 2");
+                    break;
+                case '8':
+                    EditTier(working.Tiers[2], "Tier 3");
+                    break;
+                case 'A':
+                    lock (_lock)
+                    {
+                        _deviceConfig.Encoders[encIdx] = working;
+                        SendConfig(_deviceConfig);
+                    }
+                    Console.WriteLine("  Config sent to device.");
+                    // Readback to verify
+                    Thread.Sleep(200);
+                    SendCommand(CMD_READ_CONFIG);
+                    Thread.Sleep(500);
+                    break;
+                case 'P':
+                    var preset = SelectPreset();
+                    if (preset != null)
+                        working = preset.Clone();
+                    break;
+                case 'B':
+                    return;
+            }
+        }
+    }
+
+    private static int ReadInt(string prompt, int current)
+    {
+        Console.Write($"  {prompt} [{current}]: ");
+        var input = Console.ReadLine();
+        if (string.IsNullOrWhiteSpace(input)) return current;
+        if (int.TryParse(input, out int value)) return value;
+        Console.WriteLine("  Invalid number, keeping current value.");
+        return current;
+    }
+
+    private static void EditTier(TierConfig tier, string name)
+    {
+        Console.Write($"  {name} threshold ms [{tier.ThresholdMs}] (0 to disable): ");
+        var input = Console.ReadLine();
+        if (!string.IsNullOrWhiteSpace(input) && ushort.TryParse(input, out ushort thresh))
+            tier.ThresholdMs = thresh;
+
+        if (tier.ThresholdMs > 0)
+        {
+            Console.Write($"  {name} multiplier [{tier.Multiplier}]: ");
+            input = Console.ReadLine();
+            if (!string.IsNullOrWhiteSpace(input) && ushort.TryParse(input, out ushort mult))
+                tier.Multiplier = mult;
+        }
+    }
+
+    private static EncoderConfig? SelectPreset()
+    {
+        Console.WriteLine("  Presets:");
+        var presetNames = Presets.Keys.ToArray();
+        for (int i = 0; i < presetNames.Length; i++)
+            Console.WriteLine($"    [{i + 1}] {presetNames[i]}");
+        Console.Write("  Select preset: ");
+
+        var k = Console.ReadKey(true);
+        Console.WriteLine(k.KeyChar);
+        int idx = k.KeyChar - '1';
+        if (idx >= 0 && idx < presetNames.Length)
+        {
+            Console.WriteLine($"  Loaded preset: {presetNames[idx]}");
+            return Presets[presetNames[idx]];
+        }
+        Console.WriteLine("  Invalid selection.");
+        return null;
     }
 
     // ========================================================================
     // KEYBOARD HID MODE IMPLEMENTATION
     // ========================================================================
 
-    /// <summary>
-    /// Run in Keyboard HID mode using a low-level keyboard hook.
-    /// </summary>
     private static void RunKeyboardHidMode()
     {
         Console.WriteLine("Keyboard HID Mode");
@@ -408,38 +767,29 @@ public class Program
         Console.WriteLine();
         Console.WriteLine("Press Ctrl+C to exit.");
         Console.WriteLine();
-        Console.WriteLine("Waiting for keyboard events...");
-        Console.WriteLine("-".PadRight(40, '-'));
 
-        // Handle Ctrl+C gracefully
         Console.CancelKeyPress += (sender, e) =>
         {
             e.Cancel = true;
-            Console.WriteLine("\nShutting down...");
-            if (_hookId != IntPtr.Zero)
-            {
-                UnhookWindowsHookEx(_hookId);
-            }
+            if (_hookId != IntPtr.Zero) UnhookWindowsHookEx(_hookId);
             PostQuitMessage(0);
         };
 
-        // Install the keyboard hook
         _hookCallback = HookCallback;
         using var curProcess = System.Diagnostics.Process.GetCurrentProcess();
         using var curModule = curProcess.MainModule;
-        _hookId = SetWindowsHookEx(WH_KEYBOARD_LL, _hookCallback, 
+        _hookId = SetWindowsHookEx(WH_KEYBOARD_LL, _hookCallback,
             GetModuleHandle(curModule?.ModuleName), 0);
 
         if (_hookId == IntPtr.Zero)
         {
-            Console.WriteLine("Failed to install keyboard hook. Error: " + Marshal.GetLastWin32Error());
+            Console.WriteLine("Failed to install keyboard hook.");
             return;
         }
 
-        Console.WriteLine("Keyboard hook installed successfully.");
-        Console.WriteLine();
+        Console.WriteLine("Keyboard hook installed. Waiting for events...");
+        Console.WriteLine("-".PadRight(40, '-'));
 
-        // Message loop - required for the hook to work
         MSG msg;
         while (GetMessage(out msg, IntPtr.Zero, 0, 0))
         {
@@ -447,9 +797,8 @@ public class Program
             DispatchMessage(ref msg);
         }
 
-        // Cleanup
         UnhookWindowsHookEx(_hookId);
-        Console.WriteLine("Keyboard hook removed. Goodbye!");
+        Console.WriteLine("Goodbye!");
     }
 
     private static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
@@ -457,53 +806,19 @@ public class Program
         if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
         {
             var hookStruct = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
-            int vkCode = (int)hookStruct.vkCode;
-
-            // Handle RotaryUsb keys (F1-F12)
-            string? action = GetEncoderAction(vkCode);
-            if (action != null)
+            string? action = (int)hookStruct.vkCode switch
             {
+                VK_F1 => "Encoder 1: CW", VK_F2 => "Encoder 1: CCW",
+                VK_F3 => "Encoder 2: CW", VK_F4 => "Encoder 2: CCW",
+                VK_F5 => "Encoder 3: CW", VK_F6 => "Encoder 3: CCW",
+                VK_F7 => "Encoder 4: CW", VK_F8 => "Encoder 4: CCW",
+                VK_F9 => "Encoder 1: Button", VK_F10 => "Encoder 2: Button",
+                VK_F11 => "Encoder 3: Button", VK_F12 => "Encoder 4: Button",
+                _ => null
+            };
+            if (action != null)
                 Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] {action}");
-                HandleKeyboardEncoderEvent(vkCode);
-            }
         }
-
         return CallNextHookEx(_hookId, nCode, wParam, lParam);
-    }
-
-    private static string? GetEncoderAction(int vkCode)
-    {
-        return vkCode switch
-        {
-            VK_F1 => "Encoder 1: Clockwise rotation",
-            VK_F2 => "Encoder 1: Counter-clockwise rotation",
-            VK_F3 => "Encoder 2: Clockwise rotation",
-            VK_F4 => "Encoder 2: Counter-clockwise rotation",
-            VK_F5 => "Encoder 3: Clockwise rotation",
-            VK_F6 => "Encoder 3: Counter-clockwise rotation",
-            VK_F7 => "Encoder 4: Clockwise rotation",
-            VK_F8 => "Encoder 4: Counter-clockwise rotation",
-            VK_F9 => "Encoder 1: Button pressed",
-            VK_F10 => "Encoder 2: Button pressed",
-            VK_F11 => "Encoder 3: Button pressed",
-            VK_F12 => "Encoder 4: Button pressed",
-            _ => null
-        };
-    }
-
-    private static void HandleKeyboardEncoderEvent(int vkCode)
-    {
-        switch (vkCode)
-        {
-            case VK_F1:
-                Console.WriteLine("  -> Action: Could increase volume");
-                break;
-            case VK_F2:
-                Console.WriteLine("  -> Action: Could decrease volume");
-                break;
-            case VK_F9:
-                Console.WriteLine("  -> Action: Could toggle mute");
-                break;
-        }
     }
 }

--- a/windows-example/README.md
+++ b/windows-example/README.md
@@ -68,39 +68,28 @@ When the device is in Generic HID mode:
 RotaryUsb Windows Example
 =========================
 
-This application supports two modes:
-  1. Generic HID Mode - Direct device access (recommended)
-  2. Keyboard HID Mode - Keyboard hook for F1-F12 keys
+Generic HID device found! Starting...
 
-Searching for Generic HID devices...
-Found 15 HID devices total.
-Found 1 vendor-defined HID devices.
-  - VID:0x239A PID:0x80F4 UsagePage:0xFF00 Usage:0x01
-  -> Potential RotaryUsb device found!
-Generic HID device found! Starting Generic HID mode...
+Reading config from device...
 
-Generic HID Mode
-================
+RotaryUsb Configuration
+========================
+Device connected: VID:0xCAFE PID:0x4005
 
-HID Report Format:
-  Byte 0: Report ID (0x01)
-  Byte 1-4: Encoder 1-4 movement (signed, +CW/-CCW)
-  Byte 5: Button states (bit 0-3 = buttons 1-4)
-  Byte 6-7: Reserved
+Current encoder values:
+  Enc1:          0  [0 - 100, step=1]
+  Enc2:          0  [0 - 100, step=1]
+  Enc3:          0  [0 - 100, step=1]
+  Enc4:          0  [0 - 100, step=1]
 
-Press Ctrl+C to exit.
+  Buttons: [ ] [ ] [ ] [ ]
 
-Waiting for HID reports...
-------------------------------------------------------------
-Device opened successfully.
-
-[14:30:15.123] Encoder 1: CW (+1) -> Position: 1
-  -> Action: Encoder 1 could control volume (up)
-[14:30:15.456] Encoder 1: CCW (-1) -> Position: 0
-  -> Action: Encoder 1 could control volume (down)
-[14:30:16.789] Button 1: PRESSED
-  -> Action: Button 1 could toggle mute
-[14:30:16.890] Button 1: RELEASED
+[M] Monitor - Live display of encoder values
+[C] Configure encoder
+[S] Save config to device flash
+[D] Reset to defaults
+[R] Reset positions
+[Q] Quit
 ```
 
 ### Keyboard HID Mode
@@ -149,18 +138,37 @@ Keyboard hook installed successfully.
 
 ## Generic HID Report Format
 
-When using Generic HID mode, the device sends 8-byte reports:
+When using Generic HID mode with runtime configuration, the device sends 21-byte position reports (Input Report ID 0x01):
 
-| Byte | Description | Range |
-|------|-------------|-------|
-| 0 | Report ID | Always 0x01 |
-| 1 | Encoder 1 movement | -127 to +127 (signed, positive = CW) |
-| 2 | Encoder 2 movement | -127 to +127 (signed, positive = CW) |
-| 3 | Encoder 3 movement | -127 to +127 (signed, positive = CW) |
-| 4 | Encoder 4 movement | -127 to +127 (signed, positive = CW) |
-| 5 | Button states | Bit 0-3: Buttons 1-4 (1 = pressed) |
-| 6 | Reserved | 0x00 |
-| 7 | Reserved | 0x00 |
+| Offset | Type | Description |
+|--------|------|-------------|
+| 0-3 | int32 LE | Encoder 1 absolute position |
+| 4-7 | int32 LE | Encoder 2 absolute position |
+| 8-11 | int32 LE | Encoder 3 absolute position |
+| 12-15 | int32 LE | Encoder 4 absolute position |
+| 16 | uint8 | Button states (bit 0-3 = buttons 1-4) |
+| 17 | uint8 | Active acceleration tiers (packed 2-bit per encoder) |
+| 18-20 | uint8[3] | Reserved (0x00) |
+
+## Runtime Configuration Menu
+
+In Generic HID mode, the application provides an interactive configuration menu:
+
+- **[M] Monitor** - Live display of encoder positions and acceleration tiers
+- **[C] Configure** - Edit per-encoder settings (min/max/step/wrap/reverse/acceleration)
+- **[S] Save** - Save current config to device flash
+- **[D] Defaults** - Reset device to factory defaults
+- **[R] Reset positions** - Reset all encoder positions to min_value
+- **[Q] Quit**
+
+### Built-in Presets
+
+| Preset | Min | Max | Step | Wrap | Accel Tiers |
+|--------|-----|-----|------|------|-------------|
+| General Purpose | 0 | 100 | 1 | No | 5x/15x/50x |
+| Radio Tuner (kHz) | 88,000 | 108,000 | 100 | Yes | 10x/100x/1000x |
+| Audio Mixer (%) | 0 | 100 | 1 | No | 2x/5x/10x |
+| Fine Control | 0 | 10,000 | 1 | No | 5x/25x/100x |
 
 ## USB Device Identification
 
@@ -172,39 +180,7 @@ If your device uses different identifiers, update the `KNOWN_VIDS` and `KNOWN_PI
 
 ## Customization
 
-### Adding Custom Handlers (Generic HID Mode)
-
-Edit the `HandleEncoderMovement` and `HandleButtonPress` methods in `Program.cs`:
-
-```csharp
-private static void HandleEncoderMovement(int encoderNumber, int movement, int position)
-{
-    switch (encoderNumber)
-    {
-        case 1:
-            // Your custom action for encoder 1
-            AdjustVolume(movement);
-            break;
-        case 2:
-            // Your custom action for encoder 2
-            AdjustBrightness(movement);
-            break;
-    }
-}
-
-private static void HandleButtonPress(int buttonNumber)
-{
-    switch (buttonNumber)
-    {
-        case 1:
-            ToggleMute();
-            break;
-        case 2:
-            ResetSettings();
-            break;
-    }
-}
-```
+The application uses an interactive menu for configuration. To add custom behavior when encoder values change, modify the `ReportReaderLoop` method in `Program.cs` where position reports are parsed.
 
 ### Adding Custom Handlers (Keyboard HID Mode)
 


### PR DESCRIPTION
## Summary

- Add runtime-configurable absolute position tracking with acceleration to Generic HID encoders
- Host sends config via HID Output Reports; device persists to flash and sends position data via Input Reports
- Both CircuitPython and C++ firmware rewritten with config structs, validation, 3-tier acceleration, and flash persistence
- Windows console app rewritten with interactive config menu, live monitor, and 4 built-in presets (General Purpose, Radio Tuner, Audio Mixer, Fine Control)
- Shared config logic extracted to `firmware/config.py` with 34 desktop-runnable tests

## Test Plan

- [x] 34 Python config logic tests pass (serialization, validation, wrapping, acceleration)
- [x] All CircuitPython files pass `py_compile` syntax check
- [x] Windows console app builds with 0 warnings, 0 errors
- [ ] C++ firmware builds with Pico SDK (no SDK on dev machine — verify on build host)
- [ ] Hardware UAT: flash CircuitPython firmware, verify position tracking and config persistence
- [ ] Hardware UAT: flash C++ firmware, verify same behavior
- [ ] End-to-end: Windows app config menu sends config, device applies and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)